### PR TITLE
Use BAC with PACE as backup

### DIFF
--- a/lib/src/passport_issuer.dart
+++ b/lib/src/passport_issuer.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:vcmrtd/src/types/irma_session_pointer.dart';
-import 'package:vcmrtd/src/types/verification_response.dart';
 import 'package:vcmrtd/vcmrtd.dart';
 
 /// Interface for passport issuance http requests so they can be mocked/spied in the integration tests

--- a/lib/src/passport_reader.dart
+++ b/lib/src/passport_reader.dart
@@ -361,15 +361,6 @@ class PassportReader extends StateNotifier<PassportReaderState> {
 enum _AuthMethod { none, bac, pace }
 
 class _Session {
-  static const Set<String> paceCountriesAlpha3 = {
-    'AUT', 'BEL', 'BGR', 'HRV', 'CYP', 'CZE', 'DNK', 'EST', 'FIN', 'FRA', 'DEU', 'GRC', // EU 27
-    'HUN', 'IRL', 'ITA', 'LVA', 'LTU', 'LUX', 'MLT', 'NLD', 'POL', 'PRT', 'ROU', 'SVK', // EU 27
-    'SVN', 'ESP', 'SWE', // EU 27
-    'ISL', 'LIE', 'NOR', // EEA
-    'CHE', // Switzerland
-    'GBR', // Great Britain
-  };
-
   final NfcProvider nfc;
   final String documentNumber;
   final DateTime birthDate;


### PR DESCRIPTION
First use BAC and if that's not available (throws an error) we use PACE as the backup. This works fast and is compatible with older passports.