### PR TITLE
Support binary coded decimal dates in DG12

### DIFF
--- a/lib/src/parsers/passport_parser.dart
+++ b/lib/src/parsers/passport_parser.dart
@@ -414,7 +414,12 @@ class PassportParser extends DocumentParser<PassportData> {
           issuingAuthority = utf8.decode(uvtv.value);
           break;
         case DATE_OF_ISSUE_TAG:
-          dateOfIssue = String.fromCharCodes(uvtv.value).parseDate();
+          if (uvtv.value.length == 4) {
+            final bcd = [for (var byte in uvtv.value) byte.toRadixString(16).padLeft(2, '0')].join();
+            dateOfIssue = bcd.parseDate();
+          } else {
+            dateOfIssue = String.fromCharCodes(uvtv.value).parseDate();
+          }
           break;
       }
     }

--- a/lib/src/parsers/passport_parser.dart
+++ b/lib/src/parsers/passport_parser.dart
@@ -414,7 +414,7 @@ class PassportParser extends DocumentParser<PassportData> {
           issuingAuthority = utf8.decode(uvtv.value);
           break;
         case DATE_OF_ISSUE_TAG:
-          if (uvtv.value.length == 4) {
+          if (uvtv.value.length == 4 || uvtv.value.length == 3) {
             final bcd = [for (var byte in uvtv.value) byte.toRadixString(16).padLeft(2, '0')].join();
             dateOfIssue = bcd.parseDate();
           } else {


### PR DESCRIPTION
Austrian passports apparently use binary coded decimal dates in DG12, this caused a complete failure in reading.

This simply converts the Uint8List into a hexadecimal string if the date is exactly 4 bytes long and treats it like a date string. 
There might be a better way of doing it (without dealing with strings) but this seems to work fine.



As a side note: I don't know if it might also be a good idea to not fail entirely when a single document could not be parsed / is malformed but this is not addressed here.