### PR TITLE
Fix PACE-CAM failing for German passports (#120)

### DIFF
--- a/lib/src/lds/asn1ObjectIdentifiers.dart
+++ b/lib/src/lds/asn1ObjectIdentifiers.dart
@@ -9,6 +9,43 @@ import '../types/exception.dart';
 
 // here you can add additional object identifiers that are not defined in pointycastle library
 
+// ----------------------------------------------------------------------------
+// Base OIDs used for dispatching heterogeneous `SecurityInfos` entries
+// (ICAO 9303 Part 11 §9.2). Concrete cipher-specific OIDs (e.g.
+// id-PACE-ECDH-CAM-AES-CBC-CMAC-128) are children of these base OIDs.
+//
+// Matches gmrtd/oid/oid.go so vcmrtd's SecurityInfos dispatcher can be
+// compared 1:1 against the reference implementation.
+// ----------------------------------------------------------------------------
+
+// PACE protocol families (children of id-PACE = 0.4.0.127.0.7.2.2.4)
+const String oidPaceDhGm = '0.4.0.127.0.7.2.2.4.1';
+const String oidPaceEcdhGm = '0.4.0.127.0.7.2.2.4.2';
+const String oidPaceDhIm = '0.4.0.127.0.7.2.2.4.3';
+const String oidPaceEcdhIm = '0.4.0.127.0.7.2.2.4.4';
+const String oidPaceEcdhCam = '0.4.0.127.0.7.2.2.4.6';
+
+// Chip Authentication (children of id-CA = 0.4.0.127.0.7.2.2.3)
+const String oidCaDh = '0.4.0.127.0.7.2.2.3.1';
+const String oidCaEcdh = '0.4.0.127.0.7.2.2.3.2';
+
+// Chip Authentication public keys (children of id-PK = 0.4.0.127.0.7.2.2.1)
+const String oidPkDh = '0.4.0.127.0.7.2.2.1.1';
+const String oidPkEcdh = '0.4.0.127.0.7.2.2.1.2';
+
+// Terminal Authentication
+const String oidTa = '0.4.0.127.0.7.2.2.2';
+
+// Active Authentication (id-icao-mrtd-security-aaProtocolObject)
+const String oidAaProtocol = '2.23.136.1.1.5';
+
+// EF.DIR info (id-EFDIR)
+const String oidEfDir = '1.3.27.1.1.13';
+
+/// Strict OID prefix test: `oid` must have strictly more arcs than [prefix].
+/// Equivalent to gmrtd's `OidHasPrefix`.
+bool oidHasPrefix(String oid, String prefix) => oid.startsWith('$prefix.');
+
 /*
   ID_PACE_DH_GM_3DES_CBC_CBC,       0.4.0.127.0.7.2.2.4.1.1
   ID_PACE_DH_GM_AES_CBC_CMAC_128,   0.4.0.127.0.7.2.2.4.1.2

--- a/lib/src/lds/efcard_access.dart
+++ b/lib/src/lds/efcard_access.dart
@@ -6,17 +6,38 @@ import 'dart:typed_data';
 import 'package:vcmrtd/extensions.dart';
 import "package:vcmrtd/src/lds/df1/dg.dart";
 import 'package:logging/logging.dart';
-import 'package:pointycastle/asn1.dart';
 
+import '../lds/asn1ObjectIdentifiers.dart';
 import 'ef.dart';
 import 'substruct/pace_info.dart';
+import 'substruct/security_infos.dart';
 
 class EfCardAccess extends ElementaryFile {
   static const FID = 0x011C;
   static const SFI = 0x1C;
   static const TAG = DgTag(0x6C);
 
-  PaceInfo? paceInfo;
+  SecurityInfos? _securityInfos;
+
+  /// All SecurityInfos parsed from this EF.CardAccess file.
+  ///
+  /// EF.CardAccess is a `SET OF SecurityInfo` (ICAO 9303 Part 11 §9.2) and may
+  /// contain heterogeneous entries — PACEInfo, PACEDomainParameterInfo,
+  /// ChipAuthenticationInfo, ChipAuthenticationPublicKeyInfo,
+  /// TerminalAuthenticationInfo, ActiveAuthenticationInfo, EFDIRInfo — in any
+  /// combination. Use this getter when you need to inspect the full set;
+  /// most callers want [paceInfo] for the preferred PACEInfo.
+  SecurityInfos? get securityInfos => _securityInfos;
+
+  /// Preferred `PACEInfo` for running a PACE session.
+  ///
+  /// When a chip advertises multiple PACEInfos (e.g. German ePassports
+  /// advertise both `id-PACE-ECDH-GM-AES-CBC-CMAC-128` and
+  /// `id-PACE-ECDH-CAM-AES-CBC-CMAC-128`), this getter returns the
+  /// cryptographically strongest one: CAM is preferred over GM, GM is
+  /// preferred over IM, and within the same mapping type a larger key
+  /// length wins. Returns `null` if the file advertises no PACEInfo.
+  PaceInfo? get paceInfo => _selectPreferredPaceInfo(_securityInfos?.paceInfos);
 
   bool get isPaceInfoSet => paceInfo != null;
 
@@ -34,68 +55,51 @@ class EfCardAccess extends ElementaryFile {
   void parse(Uint8List content) {
     _log.sdVerbose("Parsing EF.CardAccess${content.hex()}");
 
-    var parser = ASN1Parser(content);
-    if (!parser.hasNext()) {
-      _log.error("Invalid structure of EF.CardAccess. No data to parse.");
-      throw EfParseError("Invalid structure of EF.CardAccess. No data to parse.");
-    }
+    _securityInfos = SecurityInfos.parse(content);
 
-    ASN1Set set = parser.nextObject() as ASN1Set;
+    _log.info(
+      "Parsed EF.CardAccess SecurityInfos: "
+      "total=${_securityInfos!.totalCount}, "
+      "paceInfos=${_securityInfos!.paceInfos.length}, "
+      "paceDomainParameterInfos=${_securityInfos!.paceDomainParameterInfos.length}, "
+      "activeAuthenticationInfos=${_securityInfos!.activeAuthenticationInfos.length}, "
+      "chipAuthenticationInfos=${_securityInfos!.chipAuthenticationInfos.length}, "
+      "chipAuthenticationPublicKeyInfos=${_securityInfos!.chipAuthenticationPublicKeyInfos.length}, "
+      "terminalAuthenticationInfos=${_securityInfos!.terminalAuthenticationInfos.length}, "
+      "efDirInfos=${_securityInfos!.efDirInfos.length}, "
+      "unhandled=${_securityInfos!.unhandledInfos.length}",
+    );
+  }
+}
 
-    // there are 2 structures of EF.CardAccess but second one is not required
-    // - PaceInfo
-    // - PACEDomainParameterInfo
+/// Selects the cryptographically strongest `PaceInfo` from [infos].
+///
+/// Preference order:
+///   1. Mapping type: CAM > GM > IM (CAM additionally authenticates the chip
+///      and is strictly stronger than GM; see ICAO 9303 p11 §4.4).
+///   2. Key length (s256 > s192 > s128) within the same mapping type.
+PaceInfo? _selectPreferredPaceInfo(List<PaceInfo>? infos) {
+  if (infos == null || infos.isEmpty) {
+    return null;
+  }
+  final sorted = [...infos];
+  sorted.sort((a, b) {
+    final byMapping =
+        _mappingPreference(b.protocol.mappingType) -
+            _mappingPreference(a.protocol.mappingType);
+    if (byMapping != 0) return byMapping;
+    return b.protocol.keyLength.value.compareTo(a.protocol.keyLength.value);
+  });
+  return sorted.first;
+}
 
-    if (set.elements == null || set.elements!.isEmpty) {
-      _log.error("Invalid structure of EF.CardAccess. More than one element in set.");
-      throw EfParseError("Invalid structure of EF.CardAccess. More than one element in set.");
-    }
-
-    if (set.elements![0] is! ASN1Sequence) {
-      _log.error("Invalid structure of EF.CardAccess. First element in set is not ASN1Sequence.");
-      throw EfParseError("Invalid structure of EF.CardAccess. First element in set is not ASN1Sequence.");
-    }
-
-    PaceInfo pi = PaceInfo(content: set.elements![0] as ASN1Sequence);
-    _log.info("PaceInfo parsed.");
-
-    _log.sdDebug("PaceInfo: $pi");
-
-    paceInfo = pi;
-
-    _log.severe("PaceInfo substruct has been saved to efcardaccess member ( paceInfo )");
-
-    //TODO: parse PACEDomainParameterInfo(9303 p11, 9.2.1)
-    /*
-      PACEDomainParameterInfo ::= SEQUENCE {
-        protocol OBJECT IDENTIFIER(
-        id-PACE-DH-GM |
-        id-PACE-ECDH-GM |
-        id-PACE-DH-IM |
-        id-PACE-ECDH-IM |
-        id-PACE-ECDH-CAM),
-        domainParameter AlgorithmIdentifier,
-        parameterId INTEGER OPTIONAL
-      }
-     */
-
-    /*String paceOID = "id-PACE-ECDH-GM-AES-CBC-CMAC-128"; //0.4.0.127.0.7.2.2.4.2.2
-    int parameterSpec = 2;
-    PaceMappingType paceMappingType = PaceMappingType.GM;
-    String aggrementAlgorithm = "ECDH";
-    String cipherAlgorithm = "AES";
-    String digestAlgorithm = "SHA-1";
-    int keyLength = 128;
-    String mrzKey = "PB1777140590020743305304";
-
-    //List<int> buf = utf8.encode(mrzKey);
-    Uint8List buf = Uint8List.fromList(utf8.encode(mrzKey));
-    Digest sha1 = Digest("SHA-1");
-    List<int> sha1Bytes = sha1.process(buf);
-    String sha1Hex = sha1Bytes.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
-
-    var smskg = SecureMessagingSessionKeyGenerator();
-    var key = await smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: null, mode: SecureMessagingSessionKeyDerivationMode.PACE_MODE, paceKeyReference: paceKeyType);
-    return key;*/
+int _mappingPreference(MAPPING_TYPE mappingType) {
+  switch (mappingType) {
+    case MAPPING_TYPE.CAM:
+      return 2;
+    case MAPPING_TYPE.GM:
+      return 1;
+    case MAPPING_TYPE.IM:
+      return 0;
   }
 }

--- a/lib/src/lds/efcard_access.dart
+++ b/lib/src/lds/efcard_access.dart
@@ -84,9 +84,7 @@ PaceInfo? _selectPreferredPaceInfo(List<PaceInfo>? infos) {
   }
   final sorted = [...infos];
   sorted.sort((a, b) {
-    final byMapping =
-        _mappingPreference(b.protocol.mappingType) -
-            _mappingPreference(a.protocol.mappingType);
+    final byMapping = _mappingPreference(b.protocol.mappingType) - _mappingPreference(a.protocol.mappingType);
     if (byMapping != 0) return byMapping;
     return b.protocol.keyLength.value.compareTo(a.protocol.keyLength.value);
   });

--- a/lib/src/lds/substruct/security_infos.dart
+++ b/lib/src/lds/substruct/security_infos.dart
@@ -48,27 +48,20 @@ bool _isPaceInfo(String oid) =>
 
 /// `PACEDomainParameterInfo` — OID is exactly one of the 5 PACE base OIDs.
 bool _isPaceDomainParameterInfo(String oid) =>
-    oid == oidPaceDhGm ||
-    oid == oidPaceEcdhGm ||
-    oid == oidPaceDhIm ||
-    oid == oidPaceEcdhIm ||
-    oid == oidPaceEcdhCam;
+    oid == oidPaceDhGm || oid == oidPaceEcdhGm || oid == oidPaceDhIm || oid == oidPaceEcdhIm || oid == oidPaceEcdhCam;
 
 /// `ActiveAuthenticationInfo` — OID is `id-icao-mrtd-security-aaProtocolObject`.
 bool _isActiveAuthenticationInfo(String oid) => oid == oidAaProtocol;
 
 /// `ChipAuthenticationInfo` — OID is a strict child of `id-CA-DH` or
 /// `id-CA-ECDH`.
-bool _isChipAuthenticationInfo(String oid) =>
-    oidHasPrefix(oid, oidCaDh) || oidHasPrefix(oid, oidCaEcdh);
+bool _isChipAuthenticationInfo(String oid) => oidHasPrefix(oid, oidCaDh) || oidHasPrefix(oid, oidCaEcdh);
 
 /// `ChipAuthenticationPublicKeyInfo` — OID is exactly `id-PK-DH` or `id-PK-ECDH`.
-bool _isChipAuthenticationPublicKeyInfo(String oid) =>
-    oid == oidPkDh || oid == oidPkEcdh;
+bool _isChipAuthenticationPublicKeyInfo(String oid) => oid == oidPkDh || oid == oidPkEcdh;
 
 /// `TerminalAuthenticationInfo` — OID is `id-TA` or a child of `id-TA`.
-bool _isTerminalAuthenticationInfo(String oid) =>
-    oid == oidTa || oidHasPrefix(oid, oidTa);
+bool _isTerminalAuthenticationInfo(String oid) => oid == oidTa || oidHasPrefix(oid, oidTa);
 
 /// `EFDIRInfo` — OID is exactly `id-EFDIR`.
 bool _isEfDirInfo(String oid) => oid == oidEfDir;
@@ -82,11 +75,7 @@ class PaceDomainParameterInfo {
   final ASN1Sequence domainParameter;
   final int? parameterId;
 
-  PaceDomainParameterInfo({
-    required this.protocol,
-    required this.domainParameter,
-    required this.parameterId,
-  });
+  PaceDomainParameterInfo({required this.protocol, required this.domainParameter, required this.parameterId});
 }
 
 class ActiveAuthenticationInfo {
@@ -94,11 +83,7 @@ class ActiveAuthenticationInfo {
   final int version;
   final String signatureAlgorithm;
 
-  ActiveAuthenticationInfo({
-    required this.protocol,
-    required this.version,
-    required this.signatureAlgorithm,
-  });
+  ActiveAuthenticationInfo({required this.protocol, required this.version, required this.signatureAlgorithm});
 }
 
 class ChipAuthenticationInfo {
@@ -106,11 +91,7 @@ class ChipAuthenticationInfo {
   final int version;
   final int? keyId;
 
-  ChipAuthenticationInfo({
-    required this.protocol,
-    required this.version,
-    required this.keyId,
-  });
+  ChipAuthenticationInfo({required this.protocol, required this.version, required this.keyId});
 }
 
 class ChipAuthenticationPublicKeyInfo {
@@ -156,8 +137,7 @@ class SecurityInfos {
   final List<PaceDomainParameterInfo> paceDomainParameterInfos = [];
   final List<ActiveAuthenticationInfo> activeAuthenticationInfos = [];
   final List<ChipAuthenticationInfo> chipAuthenticationInfos = [];
-  final List<ChipAuthenticationPublicKeyInfo> chipAuthenticationPublicKeyInfos =
-      [];
+  final List<ChipAuthenticationPublicKeyInfo> chipAuthenticationPublicKeyInfos = [];
   final List<TerminalAuthenticationInfo> terminalAuthenticationInfos = [];
   final List<EfDirInfo> efDirInfos = [];
   final List<UnhandledInfo> unhandledInfos = [];
@@ -187,9 +167,7 @@ class SecurityInfos {
     }
     final top = parser.nextObject();
     if (top is! ASN1Set) {
-      throw EfParseError(
-        "Invalid SecurityInfos. Top-level object is not an ASN.1 SET.",
-      );
+      throw EfParseError("Invalid SecurityInfos. Top-level object is not an ASN.1 SET.");
     }
 
     final elements = top.elements;
@@ -249,13 +227,11 @@ class SecurityInfos {
         return;
       }
       if (_isChipAuthenticationPublicKeyInfo(oid)) {
-        chipAuthenticationPublicKeyInfos
-            .add(_parseChipAuthenticationPublicKeyInfo(oid, seq));
+        chipAuthenticationPublicKeyInfos.add(_parseChipAuthenticationPublicKeyInfo(oid, seq));
         return;
       }
       if (_isTerminalAuthenticationInfo(oid)) {
-        terminalAuthenticationInfos
-            .add(_parseTerminalAuthenticationInfo(oid, seq));
+        terminalAuthenticationInfos.add(_parseTerminalAuthenticationInfo(oid, seq));
         return;
       }
       if (_isEfDirInfo(oid)) {
@@ -270,76 +246,44 @@ class SecurityInfos {
     unhandledInfos.add(UnhandledInfo(protocol: oid, raw: seq));
   }
 
-  PaceDomainParameterInfo _parsePaceDomainParameterInfo(
-    String oid,
-    ASN1Sequence seq,
-  ) {
+  PaceDomainParameterInfo _parsePaceDomainParameterInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final domainParameter = els[1] as ASN1Sequence;
     int? parameterId;
     if (els.length >= 3) {
       parameterId = (els[2] as ASN1Integer).integer?.toInt();
     }
-    return PaceDomainParameterInfo(
-      protocol: oid,
-      domainParameter: domainParameter,
-      parameterId: parameterId,
-    );
+    return PaceDomainParameterInfo(protocol: oid, domainParameter: domainParameter, parameterId: parameterId);
   }
 
-  ActiveAuthenticationInfo _parseActiveAuthenticationInfo(
-    String oid,
-    ASN1Sequence seq,
-  ) {
+  ActiveAuthenticationInfo _parseActiveAuthenticationInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final version = (els[1] as ASN1Integer).integer!.toInt();
-    final sigAlg =
-        (els[2] as ASN1ObjectIdentifier).objectIdentifierAsString!;
-    return ActiveAuthenticationInfo(
-      protocol: oid,
-      version: version,
-      signatureAlgorithm: sigAlg,
-    );
+    final sigAlg = (els[2] as ASN1ObjectIdentifier).objectIdentifierAsString!;
+    return ActiveAuthenticationInfo(protocol: oid, version: version, signatureAlgorithm: sigAlg);
   }
 
-  ChipAuthenticationInfo _parseChipAuthenticationInfo(
-    String oid,
-    ASN1Sequence seq,
-  ) {
+  ChipAuthenticationInfo _parseChipAuthenticationInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final version = (els[1] as ASN1Integer).integer!.toInt();
     int? keyId;
     if (els.length >= 3) {
       keyId = (els[2] as ASN1Integer).integer?.toInt();
     }
-    return ChipAuthenticationInfo(
-      protocol: oid,
-      version: version,
-      keyId: keyId,
-    );
+    return ChipAuthenticationInfo(protocol: oid, version: version, keyId: keyId);
   }
 
-  ChipAuthenticationPublicKeyInfo _parseChipAuthenticationPublicKeyInfo(
-    String oid,
-    ASN1Sequence seq,
-  ) {
+  ChipAuthenticationPublicKeyInfo _parseChipAuthenticationPublicKeyInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final spki = els[1] as ASN1Sequence;
     int? keyId;
     if (els.length >= 3) {
       keyId = (els[2] as ASN1Integer).integer?.toInt();
     }
-    return ChipAuthenticationPublicKeyInfo(
-      protocol: oid,
-      chipAuthenticationPublicKey: spki,
-      keyId: keyId,
-    );
+    return ChipAuthenticationPublicKeyInfo(protocol: oid, chipAuthenticationPublicKey: spki, keyId: keyId);
   }
 
-  TerminalAuthenticationInfo _parseTerminalAuthenticationInfo(
-    String oid,
-    ASN1Sequence seq,
-  ) {
+  TerminalAuthenticationInfo _parseTerminalAuthenticationInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final version = (els[1] as ASN1Integer).integer!.toInt();
     return TerminalAuthenticationInfo(protocol: oid, version: version);
@@ -348,9 +292,6 @@ class SecurityInfos {
   EfDirInfo _parseEfDirInfo(String oid, ASN1Sequence seq) {
     final els = seq.elements!;
     final octetString = els[1] as ASN1OctetString;
-    return EfDirInfo(
-      protocol: oid,
-      efDir: Uint8List.fromList(octetString.octets ?? Uint8List(0)),
-    );
+    return EfDirInfo(protocol: oid, efDir: Uint8List.fromList(octetString.octets ?? Uint8List(0)));
   }
 }

--- a/lib/src/lds/substruct/security_infos.dart
+++ b/lib/src/lds/substruct/security_infos.dart
@@ -28,69 +28,50 @@ import 'package:pointycastle/asn1/primitives/asn1_octet_string.dart';
 import 'package:pointycastle/asn1/primitives/asn1_sequence.dart';
 import 'package:pointycastle/asn1/primitives/asn1_set.dart';
 
+import '../asn1ObjectIdentifiers.dart';
 import '../ef.dart';
 import 'pace_info.dart';
 
 // ----------------------------------------------------------------------------
-// Base OIDs (ICAO 9303 Part 11 §9.2), matching gmrtd/oid/oid.go.
-// ----------------------------------------------------------------------------
-
-const String _oidPaceDhGm = '0.4.0.127.0.7.2.2.4.1';
-const String _oidPaceEcdhGm = '0.4.0.127.0.7.2.2.4.2';
-const String _oidPaceDhIm = '0.4.0.127.0.7.2.2.4.3';
-const String _oidPaceEcdhIm = '0.4.0.127.0.7.2.2.4.4';
-const String _oidPaceEcdhCam = '0.4.0.127.0.7.2.2.4.6';
-const String _oidTa = '0.4.0.127.0.7.2.2.2';
-const String _oidCaDh = '0.4.0.127.0.7.2.2.3.1';
-const String _oidCaEcdh = '0.4.0.127.0.7.2.2.3.2';
-const String _oidPkDh = '0.4.0.127.0.7.2.2.1.1';
-const String _oidPkEcdh = '0.4.0.127.0.7.2.2.1.2';
-const String _oidAaProtocol = '2.23.136.1.1.5';
-const String _oidEfDir = '1.3.27.1.1.13';
-
-/// Strict OID prefix test: `oid` must have strictly more arcs than `prefix`
-/// (matches gmrtd's `OidHasPrefix`).
-bool _oidHasPrefix(String oid, String prefix) =>
-    oid.startsWith('$prefix.');
-
-// ----------------------------------------------------------------------------
-// Type predicates — mirror the `isXxx` helpers in gmrtd/document/security_infos.go.
+// Type predicates — mirror the `isXxx` helpers in
+// gmrtd/document/security_infos.go. Base OIDs and `oidHasPrefix` live in
+// asn1ObjectIdentifiers.dart.
 // ----------------------------------------------------------------------------
 
 /// `PACEInfo` — OID is a strict child of one of the 5 PACE base OIDs.
 bool _isPaceInfo(String oid) =>
-    _oidHasPrefix(oid, _oidPaceDhGm) ||
-    _oidHasPrefix(oid, _oidPaceEcdhGm) ||
-    _oidHasPrefix(oid, _oidPaceDhIm) ||
-    _oidHasPrefix(oid, _oidPaceEcdhIm) ||
-    _oidHasPrefix(oid, _oidPaceEcdhCam);
+    oidHasPrefix(oid, oidPaceDhGm) ||
+    oidHasPrefix(oid, oidPaceEcdhGm) ||
+    oidHasPrefix(oid, oidPaceDhIm) ||
+    oidHasPrefix(oid, oidPaceEcdhIm) ||
+    oidHasPrefix(oid, oidPaceEcdhCam);
 
 /// `PACEDomainParameterInfo` — OID is exactly one of the 5 PACE base OIDs.
 bool _isPaceDomainParameterInfo(String oid) =>
-    oid == _oidPaceDhGm ||
-    oid == _oidPaceEcdhGm ||
-    oid == _oidPaceDhIm ||
-    oid == _oidPaceEcdhIm ||
-    oid == _oidPaceEcdhCam;
+    oid == oidPaceDhGm ||
+    oid == oidPaceEcdhGm ||
+    oid == oidPaceDhIm ||
+    oid == oidPaceEcdhIm ||
+    oid == oidPaceEcdhCam;
 
 /// `ActiveAuthenticationInfo` — OID is `id-icao-mrtd-security-aaProtocolObject`.
-bool _isActiveAuthenticationInfo(String oid) => oid == _oidAaProtocol;
+bool _isActiveAuthenticationInfo(String oid) => oid == oidAaProtocol;
 
 /// `ChipAuthenticationInfo` — OID is a strict child of `id-CA-DH` or
 /// `id-CA-ECDH`.
 bool _isChipAuthenticationInfo(String oid) =>
-    _oidHasPrefix(oid, _oidCaDh) || _oidHasPrefix(oid, _oidCaEcdh);
+    oidHasPrefix(oid, oidCaDh) || oidHasPrefix(oid, oidCaEcdh);
 
 /// `ChipAuthenticationPublicKeyInfo` — OID is exactly `id-PK-DH` or `id-PK-ECDH`.
 bool _isChipAuthenticationPublicKeyInfo(String oid) =>
-    oid == _oidPkDh || oid == _oidPkEcdh;
+    oid == oidPkDh || oid == oidPkEcdh;
 
 /// `TerminalAuthenticationInfo` — OID is `id-TA` or a child of `id-TA`.
 bool _isTerminalAuthenticationInfo(String oid) =>
-    oid == _oidTa || _oidHasPrefix(oid, _oidTa);
+    oid == oidTa || oidHasPrefix(oid, oidTa);
 
 /// `EFDIRInfo` — OID is exactly `id-EFDIR`.
-bool _isEfDirInfo(String oid) => oid == _oidEfDir;
+bool _isEfDirInfo(String oid) => oid == oidEfDir;
 
 // ----------------------------------------------------------------------------
 // Concrete SecurityInfo record types.

--- a/lib/src/lds/substruct/security_infos.dart
+++ b/lib/src/lds/substruct/security_infos.dart
@@ -1,0 +1,375 @@
+// Heterogeneous SecurityInfos parsing, modelled on gmrtd's reference
+// implementation (document/security_infos.go).
+//
+// Per ICAO 9303 Part 11 §9.2:
+//
+//   SecurityInfos ::= SET OF SecurityInfo
+//   SecurityInfo  ::= SEQUENCE {
+//     protocol      OBJECT IDENTIFIER,
+//     requiredData  ANY DEFINED BY protocol,
+//     optionalData  ANY DEFINED BY protocol OPTIONAL
+//   }
+//
+// Concrete SecurityInfo types are distinguished by the protocol OID, not by
+// position in the SET. DER `SET OF` orders elements lexicographically by
+// encoded value (X.690 §11.6), so a German ePassport advertising EAC will
+// typically place a `TerminalAuthenticationInfo` ahead of its `PACEInfo`
+// entries. This parser iterates every element in the SET and dispatches
+// through per-type handlers — matching gmrtd's `DecodeSecurityInfos` — and
+// records anything unrecognised as an `UnhandledInfo` rather than throwing.
+
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:pointycastle/asn1/asn1_parser.dart';
+import 'package:pointycastle/asn1/primitives/asn1_integer.dart';
+import 'package:pointycastle/asn1/primitives/asn1_object_identifier.dart';
+import 'package:pointycastle/asn1/primitives/asn1_octet_string.dart';
+import 'package:pointycastle/asn1/primitives/asn1_sequence.dart';
+import 'package:pointycastle/asn1/primitives/asn1_set.dart';
+
+import '../ef.dart';
+import 'pace_info.dart';
+
+// ----------------------------------------------------------------------------
+// Base OIDs (ICAO 9303 Part 11 §9.2), matching gmrtd/oid/oid.go.
+// ----------------------------------------------------------------------------
+
+const String _oidPaceDhGm = '0.4.0.127.0.7.2.2.4.1';
+const String _oidPaceEcdhGm = '0.4.0.127.0.7.2.2.4.2';
+const String _oidPaceDhIm = '0.4.0.127.0.7.2.2.4.3';
+const String _oidPaceEcdhIm = '0.4.0.127.0.7.2.2.4.4';
+const String _oidPaceEcdhCam = '0.4.0.127.0.7.2.2.4.6';
+const String _oidTa = '0.4.0.127.0.7.2.2.2';
+const String _oidCaDh = '0.4.0.127.0.7.2.2.3.1';
+const String _oidCaEcdh = '0.4.0.127.0.7.2.2.3.2';
+const String _oidPkDh = '0.4.0.127.0.7.2.2.1.1';
+const String _oidPkEcdh = '0.4.0.127.0.7.2.2.1.2';
+const String _oidAaProtocol = '2.23.136.1.1.5';
+const String _oidEfDir = '1.3.27.1.1.13';
+
+/// Strict OID prefix test: `oid` must have strictly more arcs than `prefix`
+/// (matches gmrtd's `OidHasPrefix`).
+bool _oidHasPrefix(String oid, String prefix) =>
+    oid.startsWith('$prefix.');
+
+// ----------------------------------------------------------------------------
+// Type predicates — mirror the `isXxx` helpers in gmrtd/document/security_infos.go.
+// ----------------------------------------------------------------------------
+
+/// `PACEInfo` — OID is a strict child of one of the 5 PACE base OIDs.
+bool _isPaceInfo(String oid) =>
+    _oidHasPrefix(oid, _oidPaceDhGm) ||
+    _oidHasPrefix(oid, _oidPaceEcdhGm) ||
+    _oidHasPrefix(oid, _oidPaceDhIm) ||
+    _oidHasPrefix(oid, _oidPaceEcdhIm) ||
+    _oidHasPrefix(oid, _oidPaceEcdhCam);
+
+/// `PACEDomainParameterInfo` — OID is exactly one of the 5 PACE base OIDs.
+bool _isPaceDomainParameterInfo(String oid) =>
+    oid == _oidPaceDhGm ||
+    oid == _oidPaceEcdhGm ||
+    oid == _oidPaceDhIm ||
+    oid == _oidPaceEcdhIm ||
+    oid == _oidPaceEcdhCam;
+
+/// `ActiveAuthenticationInfo` — OID is `id-icao-mrtd-security-aaProtocolObject`.
+bool _isActiveAuthenticationInfo(String oid) => oid == _oidAaProtocol;
+
+/// `ChipAuthenticationInfo` — OID is a strict child of `id-CA-DH` or
+/// `id-CA-ECDH`.
+bool _isChipAuthenticationInfo(String oid) =>
+    _oidHasPrefix(oid, _oidCaDh) || _oidHasPrefix(oid, _oidCaEcdh);
+
+/// `ChipAuthenticationPublicKeyInfo` — OID is exactly `id-PK-DH` or `id-PK-ECDH`.
+bool _isChipAuthenticationPublicKeyInfo(String oid) =>
+    oid == _oidPkDh || oid == _oidPkEcdh;
+
+/// `TerminalAuthenticationInfo` — OID is `id-TA` or a child of `id-TA`.
+bool _isTerminalAuthenticationInfo(String oid) =>
+    oid == _oidTa || _oidHasPrefix(oid, _oidTa);
+
+/// `EFDIRInfo` — OID is exactly `id-EFDIR`.
+bool _isEfDirInfo(String oid) => oid == _oidEfDir;
+
+// ----------------------------------------------------------------------------
+// Concrete SecurityInfo record types.
+// ----------------------------------------------------------------------------
+
+class PaceDomainParameterInfo {
+  final String protocol;
+  final ASN1Sequence domainParameter;
+  final int? parameterId;
+
+  PaceDomainParameterInfo({
+    required this.protocol,
+    required this.domainParameter,
+    required this.parameterId,
+  });
+}
+
+class ActiveAuthenticationInfo {
+  final String protocol;
+  final int version;
+  final String signatureAlgorithm;
+
+  ActiveAuthenticationInfo({
+    required this.protocol,
+    required this.version,
+    required this.signatureAlgorithm,
+  });
+}
+
+class ChipAuthenticationInfo {
+  final String protocol;
+  final int version;
+  final int? keyId;
+
+  ChipAuthenticationInfo({
+    required this.protocol,
+    required this.version,
+    required this.keyId,
+  });
+}
+
+class ChipAuthenticationPublicKeyInfo {
+  final String protocol;
+  final ASN1Sequence chipAuthenticationPublicKey; // SubjectPublicKeyInfo
+  final int? keyId;
+
+  ChipAuthenticationPublicKeyInfo({
+    required this.protocol,
+    required this.chipAuthenticationPublicKey,
+    required this.keyId,
+  });
+}
+
+class TerminalAuthenticationInfo {
+  final String protocol;
+  final int version;
+
+  TerminalAuthenticationInfo({required this.protocol, required this.version});
+}
+
+class EfDirInfo {
+  final String protocol;
+  final Uint8List efDir;
+
+  EfDirInfo({required this.protocol, required this.efDir});
+}
+
+class UnhandledInfo {
+  final String protocol;
+  final ASN1Sequence raw;
+
+  UnhandledInfo({required this.protocol, required this.raw});
+}
+
+// ----------------------------------------------------------------------------
+// SecurityInfos — container + parser.
+// ----------------------------------------------------------------------------
+
+class SecurityInfos {
+  final Uint8List rawData;
+  final List<PaceInfo> paceInfos = [];
+  final List<PaceDomainParameterInfo> paceDomainParameterInfos = [];
+  final List<ActiveAuthenticationInfo> activeAuthenticationInfos = [];
+  final List<ChipAuthenticationInfo> chipAuthenticationInfos = [];
+  final List<ChipAuthenticationPublicKeyInfo> chipAuthenticationPublicKeyInfos =
+      [];
+  final List<TerminalAuthenticationInfo> terminalAuthenticationInfos = [];
+  final List<EfDirInfo> efDirInfos = [];
+  final List<UnhandledInfo> unhandledInfos = [];
+
+  static final _log = Logger('SecurityInfos');
+
+  SecurityInfos._(this.rawData);
+
+  /// Total number of recognised + unhandled SecurityInfo entries.
+  int get totalCount =>
+      paceInfos.length +
+      paceDomainParameterInfos.length +
+      activeAuthenticationInfos.length +
+      chipAuthenticationInfos.length +
+      chipAuthenticationPublicKeyInfos.length +
+      terminalAuthenticationInfos.length +
+      efDirInfos.length +
+      unhandledInfos.length;
+
+  /// Parses `SecurityInfos ::= SET OF SecurityInfo` from [data].
+  factory SecurityInfos.parse(Uint8List data) {
+    final secInfos = SecurityInfos._(data);
+
+    final parser = ASN1Parser(data);
+    if (!parser.hasNext()) {
+      throw EfParseError("Invalid SecurityInfos. No data to parse.");
+    }
+    final top = parser.nextObject();
+    if (top is! ASN1Set) {
+      throw EfParseError(
+        "Invalid SecurityInfos. Top-level object is not an ASN.1 SET.",
+      );
+    }
+
+    final elements = top.elements;
+    if (elements == null) {
+      return secInfos;
+    }
+
+    for (final element in elements) {
+      if (element is! ASN1Sequence) {
+        _log.warning("Skipping non-SEQUENCE element in SecurityInfos SET");
+        continue;
+      }
+      secInfos._dispatch(element);
+    }
+
+    return secInfos;
+  }
+
+  void _dispatch(ASN1Sequence seq) {
+    final seqElements = seq.elements;
+    if (seqElements == null || seqElements.isEmpty) {
+      _log.warning("Skipping empty SecurityInfo SEQUENCE");
+      return;
+    }
+    final first = seqElements.first;
+    if (first is! ASN1ObjectIdentifier) {
+      _log.warning("Skipping SecurityInfo with non-OID first element");
+      return;
+    }
+    final oid = first.objectIdentifierAsString;
+    if (oid == null) {
+      _log.warning("Skipping SecurityInfo with unreadable OID");
+      return;
+    }
+
+    // Dispatch chain mirrors gmrtd's `securityInfoHandleFnArr`. Handlers are
+    // tried in order; anything left unhandled is recorded as `UnhandledInfo`.
+    //
+    // Individual handlers may fail to fully parse a record that is present
+    // on the chip but malformed — treat those as unhandled (with a log line)
+    // rather than aborting the whole SecurityInfos parse.
+    try {
+      if (_isPaceInfo(oid)) {
+        paceInfos.add(PaceInfo(content: seq));
+        return;
+      }
+      if (_isPaceDomainParameterInfo(oid)) {
+        paceDomainParameterInfos.add(_parsePaceDomainParameterInfo(oid, seq));
+        return;
+      }
+      if (_isActiveAuthenticationInfo(oid)) {
+        activeAuthenticationInfos.add(_parseActiveAuthenticationInfo(oid, seq));
+        return;
+      }
+      if (_isChipAuthenticationInfo(oid)) {
+        chipAuthenticationInfos.add(_parseChipAuthenticationInfo(oid, seq));
+        return;
+      }
+      if (_isChipAuthenticationPublicKeyInfo(oid)) {
+        chipAuthenticationPublicKeyInfos
+            .add(_parseChipAuthenticationPublicKeyInfo(oid, seq));
+        return;
+      }
+      if (_isTerminalAuthenticationInfo(oid)) {
+        terminalAuthenticationInfos
+            .add(_parseTerminalAuthenticationInfo(oid, seq));
+        return;
+      }
+      if (_isEfDirInfo(oid)) {
+        efDirInfos.add(_parseEfDirInfo(oid, seq));
+        return;
+      }
+    } catch (e) {
+      _log.warning("Failed to parse SecurityInfo (OID $oid): $e");
+      // fall through and record as unhandled
+    }
+
+    unhandledInfos.add(UnhandledInfo(protocol: oid, raw: seq));
+  }
+
+  PaceDomainParameterInfo _parsePaceDomainParameterInfo(
+    String oid,
+    ASN1Sequence seq,
+  ) {
+    final els = seq.elements!;
+    final domainParameter = els[1] as ASN1Sequence;
+    int? parameterId;
+    if (els.length >= 3) {
+      parameterId = (els[2] as ASN1Integer).integer?.toInt();
+    }
+    return PaceDomainParameterInfo(
+      protocol: oid,
+      domainParameter: domainParameter,
+      parameterId: parameterId,
+    );
+  }
+
+  ActiveAuthenticationInfo _parseActiveAuthenticationInfo(
+    String oid,
+    ASN1Sequence seq,
+  ) {
+    final els = seq.elements!;
+    final version = (els[1] as ASN1Integer).integer!.toInt();
+    final sigAlg =
+        (els[2] as ASN1ObjectIdentifier).objectIdentifierAsString!;
+    return ActiveAuthenticationInfo(
+      protocol: oid,
+      version: version,
+      signatureAlgorithm: sigAlg,
+    );
+  }
+
+  ChipAuthenticationInfo _parseChipAuthenticationInfo(
+    String oid,
+    ASN1Sequence seq,
+  ) {
+    final els = seq.elements!;
+    final version = (els[1] as ASN1Integer).integer!.toInt();
+    int? keyId;
+    if (els.length >= 3) {
+      keyId = (els[2] as ASN1Integer).integer?.toInt();
+    }
+    return ChipAuthenticationInfo(
+      protocol: oid,
+      version: version,
+      keyId: keyId,
+    );
+  }
+
+  ChipAuthenticationPublicKeyInfo _parseChipAuthenticationPublicKeyInfo(
+    String oid,
+    ASN1Sequence seq,
+  ) {
+    final els = seq.elements!;
+    final spki = els[1] as ASN1Sequence;
+    int? keyId;
+    if (els.length >= 3) {
+      keyId = (els[2] as ASN1Integer).integer?.toInt();
+    }
+    return ChipAuthenticationPublicKeyInfo(
+      protocol: oid,
+      chipAuthenticationPublicKey: spki,
+      keyId: keyId,
+    );
+  }
+
+  TerminalAuthenticationInfo _parseTerminalAuthenticationInfo(
+    String oid,
+    ASN1Sequence seq,
+  ) {
+    final els = seq.elements!;
+    final version = (els[1] as ASN1Integer).integer!.toInt();
+    return TerminalAuthenticationInfo(protocol: oid, version: version);
+  }
+
+  EfDirInfo _parseEfDirInfo(String oid, ASN1Sequence seq) {
+    final els = seq.elements!;
+    final octetString = els[1] as ASN1OctetString;
+    return EfDirInfo(
+      protocol: oid,
+      efDir: Uint8List.fromList(octetString.octets ?? Uint8List(0)),
+    );
+  }
+}

--- a/test/efcard_access_test.dart
+++ b/test/efcard_access_test.dart
@@ -1,0 +1,179 @@
+// Tests for EF.CardAccess SecurityInfos parsing.
+//
+// Test vectors are taken directly from gmrtd
+// (https://github.com/gmrtd/gmrtd) so that vcmrtd's behaviour can be compared
+// against an independent reference implementation that follows the same
+// ICAO 9303 Part 11 §9.2 approach.
+//
+// Reference files in gmrtd:
+//   - document/card_access_test.go      (TestNewCardAccessHappyAT / HappyDE)
+//   - document/security_infos_test.go   (TestDecodeSecurityInfos,
+//                                        TestDecodeSecurityInfosCardSecFile)
+//
+// These tests currently FAIL on master because `EfCardAccess.parse` only
+// reads `set.elements[0]` and blindly casts it to a `PaceInfo`. See
+// issue #120 for the full analysis — German passports place a
+// TerminalAuthenticationInfo (id-TA, 0.4.0.127.0.7.2.2.2) at position 0
+// under DER SET-OF ordering, which blows up the parser with
+// `Invalid protocol in PaceInfo. Protocol is not valid: 0.4.0.127.0.7.2.2.2`.
+
+import 'package:test/test.dart';
+
+import 'package:vcmrtd/vcmrtd.dart';
+import 'package:vcmrtd/extensions.dart';
+
+void main() {
+  group('EfCardAccess', () {
+    // Matches gmrtd: document/card_access_test.go TestNewCardAccessHappyAT
+    //
+    // Single PACEInfo using id-PACE-ECDH-GM-AES-CBC-CMAC-128 (0.4.0.127.0.7.2.2.4.2.2)
+    // with version=2 and parameterId=13. Representative of an Austrian passport.
+    test('Parses AT SecurityInfos with a single PACEInfo (ECDH-GM-128)', () {
+      final data =
+          '31143012060a04007f0007020204020202010202010d'.parseHex();
+
+      final ef = EfCardAccess.fromBytes(data);
+
+      expect(ef.paceInfo, isNotNull);
+      expect(
+        ef.paceInfo!.protocol.identifierString,
+        '0.4.0.127.0.7.2.2.4.2.2',
+      );
+      expect(ef.paceInfo!.version, 2);
+      expect(ef.paceInfo!.parameterId, 13);
+    });
+
+    // Matches gmrtd: document/card_access_test.go TestNewCardAccessHappyDE
+    //
+    // Two PACEInfos advertised:
+    //   - id-PACE-ECDH-GM-AES-CBC-CMAC-128  (0.4.0.127.0.7.2.2.4.2.2)
+    //   - id-PACE-ECDH-CAM-AES-CBC-CMAC-128 (0.4.0.127.0.7.2.2.4.6.2)
+    //
+    // Both entries are valid PACEInfo structures. Under DER SET-OF ordering
+    // the GM entry sorts before the CAM entry, so on the current master
+    // `elements[0]` is GM and this test happens NOT to throw. It is included
+    // because the fix (modelled on gmrtd's SecurityInfos dispatcher) should
+    // surface BOTH PACEInfos and prefer CAM when selecting the active one.
+    test('Parses DE SecurityInfos with two PACEInfos (GM + CAM)', () {
+      final data =
+          ('31283012060a04007f0007020204020202010202010d'
+                  '3012060a04007f0007020204060202010202010d')
+              .parseHex();
+
+      final ef = EfCardAccess.fromBytes(data);
+
+      expect(ef.paceInfo, isNotNull);
+      // After the fix, a CAM-capable chip should have its CAM entry selected
+      // as the preferred PACEInfo (PACE-CAM is strictly stronger than PACE-GM
+      // because it additionally authenticates the chip; ICAO 9303 p11 §4.4).
+      expect(
+        ef.paceInfo!.protocol.identifierString,
+        '0.4.0.127.0.7.2.2.4.6.2',
+      );
+      expect(ef.paceInfo!.version, 2);
+      expect(ef.paceInfo!.parameterId, 13);
+    });
+
+    // Reproduces issue #120 directly.
+    //
+    // SET contains:
+    //   1. TerminalAuthenticationInfo { protocol=id-TA (0.4.0.127.0.7.2.2.2),
+    //                                   version=2 }
+    //   2. PACEInfo { protocol=id-PACE-ECDH-CAM-AES-CBC-CMAC-128
+    //                 (0.4.0.127.0.7.2.2.4.6.2),
+    //                 version=2, parameterId=13 }
+    //
+    // Under DER SET-OF encoding (X.690 §11.6) the shorter TA encoding
+    // (15 bytes) sorts before the longer PACEInfo encoding (20 bytes),
+    // so the TA entry is `set.elements[0]`. The current master parser
+    // blindly casts it to a PACEInfo and throws:
+    //   "Invalid protocol in PaceInfo. Protocol is not valid: 0.4.0.127.0.7.2.2.2"
+    //
+    // After the fix EF.CardAccess should be parsed as a heterogeneous
+    // SET OF SecurityInfo — exactly the approach gmrtd takes in
+    // document/security_infos.go (DecodeSecurityInfos + per-type handlers).
+    test(
+      'Parses SecurityInfos with TerminalAuthenticationInfo before PACEInfo (issue #120)',
+      () {
+        // SET (len 0x23 = 35):
+        //   SEQUENCE (len 13): id-TA (0.4.0.127.0.7.2.2.2), version 2
+        //   SEQUENCE (len 18): id-PACE-ECDH-CAM-AES-CBC-CMAC-128, v2, paramId 13
+        final data =
+            ('3123'
+                    '300d060804007f0007020202020102'
+                    '3012060a04007f0007020204060202010202010d')
+                .parseHex();
+
+        final ef = EfCardAccess.fromBytes(data);
+
+        expect(ef.paceInfo, isNotNull);
+        expect(
+          ef.paceInfo!.protocol.identifierString,
+          '0.4.0.127.0.7.2.2.4.6.2',
+        );
+        expect(ef.paceInfo!.version, 2);
+        expect(ef.paceInfo!.parameterId, 13);
+      },
+    );
+
+    // Matches gmrtd: document/security_infos_test.go
+    // TestDecodeSecurityInfosCardSecFile
+    //
+    // Real-world test vector taken from the CardSecurity file of a German
+    // ePassport. The SET contains 7 SecurityInfos of mixed types, and the
+    // first element (under DER SET-OF ordering) is a TerminalAuthenticationInfo.
+    //
+    // Expected breakdown (per gmrtd reference):
+    //   - 1 x TerminalAuthenticationInfo (id-TA, version 2)
+    //   - 1 x ChipAuthenticationInfo
+    //   - 2 x PACEInfo (ECDH-GM-128 + ECDH-CAM-128, both parameterId 13)
+    //   - 1 x UnhandledInfo (malformed id-CA-ECDH entry present on the real
+    //                         German passport — must be tolerated, not throw)
+    //   - 2 x ChipAuthenticationPublicKeyInfo
+    //
+    // On master this blows up in the exact way issue #120 reports.
+    test('Parses real-world DE SecurityInfos (CardSecurity) with mixed types',
+        () {
+      final data =
+          ('31820131'
+                  '300d060804007f0007020202020102'
+                  '3012060a04007f00070202030202020102020148'
+                  '3012060a04007f0007020204020202010202010d'
+                  '3012060a04007f0007020204060202010202010d'
+                  '301c060904007f000702020302300c060704007f0007010202010d020148'
+                  '3062060904007f0007020201023052300c060704007f0007010202010d'
+                  '03420004614cd88b00821a887869d0060b44a9d18789353e8cf7dfbc3f29f79327de30b97b1b2dda0be77f24ad415c327c7b7ab2e9c10b0258f5bcbf90c01825fbdfdef702010d'
+                  '3062060904007f0007020201023052300c060704007f0007010202010d'
+                  '034200048488a2dc34b6b36d6c01a8dfbd70a874610c53b32893a1de3b1c4bbf477eef3761aa51dfd6b52da43587e95386fc34ffe178d90086a7d646047c82bebc27da3e020148')
+              .parseHex();
+
+      final ef = EfCardAccess.fromBytes(data);
+
+      expect(ef.paceInfo, isNotNull);
+      // A German passport advertising PACE-CAM must have the CAM protocol
+      // selected as the active PACEInfo.
+      expect(
+        ef.paceInfo!.protocol.identifierString,
+        '0.4.0.127.0.7.2.2.4.6.2',
+      );
+      expect(ef.paceInfo!.version, 2);
+      expect(ef.paceInfo!.parameterId, 13);
+    });
+
+    // Matches gmrtd: document/security_infos_test.go TestDecodeSecurityInfos
+    // (TermAuthInfos-only case).
+    //
+    // A stand-alone TerminalAuthenticationInfo SecurityInfos SET must not
+    // throw during parsing. There is no PACEInfo present, so `paceInfo`
+    // should simply be null / unset. The current master parser throws on
+    // this input because it tries to parse element[0] as a PACEInfo.
+    test(
+      'Does not throw on SecurityInfos containing only TerminalAuthenticationInfo',
+      () {
+        final data = '310f300d060804007f0007020202020101'.parseHex();
+
+        expect(() => EfCardAccess.fromBytes(data), returnsNormally);
+      },
+    );
+  });
+}

--- a/test/efcard_access_test.dart
+++ b/test/efcard_access_test.dart
@@ -29,16 +29,12 @@ void main() {
     // Single PACEInfo using id-PACE-ECDH-GM-AES-CBC-CMAC-128 (0.4.0.127.0.7.2.2.4.2.2)
     // with version=2 and parameterId=13. Representative of an Austrian passport.
     test('Parses AT SecurityInfos with a single PACEInfo (ECDH-GM-128)', () {
-      final data =
-          '31143012060a04007f0007020204020202010202010d'.parseHex();
+      final data = '31143012060a04007f0007020204020202010202010d'.parseHex();
 
       final ef = EfCardAccess.fromBytes(data);
 
       expect(ef.paceInfo, isNotNull);
-      expect(
-        ef.paceInfo!.protocol.identifierString,
-        '0.4.0.127.0.7.2.2.4.2.2',
-      );
+      expect(ef.paceInfo!.protocol.identifierString, '0.4.0.127.0.7.2.2.4.2.2');
       expect(ef.paceInfo!.version, 2);
       expect(ef.paceInfo!.parameterId, 13);
     });
@@ -66,10 +62,7 @@ void main() {
       // After the fix, a CAM-capable chip should have its CAM entry selected
       // as the preferred PACEInfo (PACE-CAM is strictly stronger than PACE-GM
       // because it additionally authenticates the chip; ICAO 9303 p11 §4.4).
-      expect(
-        ef.paceInfo!.protocol.identifierString,
-        '0.4.0.127.0.7.2.2.4.6.2',
-      );
+      expect(ef.paceInfo!.protocol.identifierString, '0.4.0.127.0.7.2.2.4.6.2');
       expect(ef.paceInfo!.version, 2);
       expect(ef.paceInfo!.parameterId, 13);
     });
@@ -92,29 +85,23 @@ void main() {
     // After the fix EF.CardAccess should be parsed as a heterogeneous
     // SET OF SecurityInfo — exactly the approach gmrtd takes in
     // document/security_infos.go (DecodeSecurityInfos + per-type handlers).
-    test(
-      'Parses SecurityInfos with TerminalAuthenticationInfo before PACEInfo (issue #120)',
-      () {
-        // SET (len 0x23 = 35):
-        //   SEQUENCE (len 13): id-TA (0.4.0.127.0.7.2.2.2), version 2
-        //   SEQUENCE (len 18): id-PACE-ECDH-CAM-AES-CBC-CMAC-128, v2, paramId 13
-        final data =
-            ('3123'
-                    '300d060804007f0007020202020102'
-                    '3012060a04007f0007020204060202010202010d')
-                .parseHex();
+    test('Parses SecurityInfos with TerminalAuthenticationInfo before PACEInfo (issue #120)', () {
+      // SET (len 0x23 = 35):
+      //   SEQUENCE (len 13): id-TA (0.4.0.127.0.7.2.2.2), version 2
+      //   SEQUENCE (len 18): id-PACE-ECDH-CAM-AES-CBC-CMAC-128, v2, paramId 13
+      final data =
+          ('3123'
+                  '300d060804007f0007020202020102'
+                  '3012060a04007f0007020204060202010202010d')
+              .parseHex();
 
-        final ef = EfCardAccess.fromBytes(data);
+      final ef = EfCardAccess.fromBytes(data);
 
-        expect(ef.paceInfo, isNotNull);
-        expect(
-          ef.paceInfo!.protocol.identifierString,
-          '0.4.0.127.0.7.2.2.4.6.2',
-        );
-        expect(ef.paceInfo!.version, 2);
-        expect(ef.paceInfo!.parameterId, 13);
-      },
-    );
+      expect(ef.paceInfo, isNotNull);
+      expect(ef.paceInfo!.protocol.identifierString, '0.4.0.127.0.7.2.2.4.6.2');
+      expect(ef.paceInfo!.version, 2);
+      expect(ef.paceInfo!.parameterId, 13);
+    });
 
     // Matches gmrtd: document/security_infos_test.go
     // TestDecodeSecurityInfosCardSecFile
@@ -132,8 +119,7 @@ void main() {
     //   - 2 x ChipAuthenticationPublicKeyInfo
     //
     // On master this blows up in the exact way issue #120 reports.
-    test('Parses real-world DE SecurityInfos (CardSecurity) with mixed types',
-        () {
+    test('Parses real-world DE SecurityInfos (CardSecurity) with mixed types', () {
       final data =
           ('31820131'
                   '300d060804007f0007020202020102'
@@ -152,10 +138,7 @@ void main() {
       expect(ef.paceInfo, isNotNull);
       // A German passport advertising PACE-CAM must have the CAM protocol
       // selected as the active PACEInfo.
-      expect(
-        ef.paceInfo!.protocol.identifierString,
-        '0.4.0.127.0.7.2.2.4.6.2',
-      );
+      expect(ef.paceInfo!.protocol.identifierString, '0.4.0.127.0.7.2.2.4.6.2');
       expect(ef.paceInfo!.version, 2);
       expect(ef.paceInfo!.parameterId, 13);
     });
@@ -167,13 +150,10 @@ void main() {
     // throw during parsing. There is no PACEInfo present, so `paceInfo`
     // should simply be null / unset. The current master parser throws on
     // this input because it tries to parse element[0] as a PACEInfo.
-    test(
-      'Does not throw on SecurityInfos containing only TerminalAuthenticationInfo',
-      () {
-        final data = '310f300d060804007f0007020202020101'.parseHex();
+    test('Does not throw on SecurityInfos containing only TerminalAuthenticationInfo', () {
+      final data = '310f300d060804007f0007020202020101'.parseHex();
 
-        expect(() => EfCardAccess.fromBytes(data), returnsNormally);
-      },
-    );
+      expect(() => EfCardAccess.fromBytes(data), returnsNormally);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #120. `EfCardAccess.parse` previously read only `set.elements[0]` and blindly cast it to a `PaceInfo`, which crashed on any chip whose `EF.CardAccess` contained non-PACE `SecurityInfo` entries. German ePassports support EAC and advertise a `TerminalAuthenticationInfo` alongside their PACEInfos — under DER `SET OF` ordering (X.690 §11.6) the shorter TA encoding sorts ahead of the longer PACEInfo encoding, so `elements[0]` is TA and the parser threw:

> `Invalid protocol in PaceInfo. Protocol is not valid: 0.4.0.127.0.7.2.2.2`

## Approach

Reimplemented `EF.CardAccess` parsing as a heterogeneous `SET OF SecurityInfo` dispatcher, modelled 1:1 on gmrtd's reference implementation (`document/security_infos.go`, `document/card_access.go`).

Per ICAO 9303 Part 11 §9.2 (see [`icao/9303_p11_cons_en.md`](./icao/9303_p11_cons_en.md) lines 2760-2766):

```
SecurityInfos ::= SET OF SecurityInfo
SecurityInfo  ::= SEQUENCE {
   protocol      OBJECT IDENTIFIER,
   requiredData  ANY DEFINED BY protocol,
   optionalData  ANY DEFINED BY protocol OPTIONAL
}
```

Concrete SecurityInfo types are distinguished **by protocol OID, not by position**. The new parser iterates every element and dispatches through per-type handlers.

## Changes

**New: `lib/src/lds/substruct/security_infos.dart`**
- `SecurityInfos` container with typed lists: `paceInfos`, `paceDomainParameterInfos`, `activeAuthenticationInfos`, `chipAuthenticationInfos`, `chipAuthenticationPublicKeyInfos`, `terminalAuthenticationInfos`, `efDirInfos`, `unhandledInfos`.
- OID-prefix/equality predicates mirror gmrtd's `isXxx` helpers (strict-prefix for PACE/CA variants, exact match for `id-PK`/`id-EFDIR`, both for `id-TA`).
- Handlers are tried in order; anything unrecognised is recorded as `UnhandledInfo` rather than throwing — so malformed entries on real chips (e.g. the bare `id-CA-ECDH` record present on actual DE `CardSecurity` files) no longer abort parsing.

**Updated: `lib/src/lds/efcard_access.dart`**
- Delegates to `SecurityInfos.parse()`.
- Exposes `securityInfos` for full access.
- Keeps `paceInfo` / `isPaceInfoSet` as backwards-compat getters; `paceInfo` now selects the **cryptographically strongest** PACEInfo from the advertised set — CAM > GM > IM, with larger key length winning inside a mapping type (ICAO 9303 p11 §4.4).

**Updated: `lib/src/lds/asn1ObjectIdentifiers.dart`**
- Added PACE / CA / PK / TA / AA / EFDIR base OID constants (`oidPaceDhGm`, `oidCaEcdh`, `oidTa`, …) alongside the existing customOIDs list.
- Added a reusable `oidHasPrefix(oid, prefix)` helper (strict prefix, matching gmrtd's `OidHasPrefix`).

## Tests

`test/efcard_access_test.dart` — new, test vectors copied from gmrtd (`document/card_access_test.go` + `document/security_infos_test.go`):

| # | Test | Before | After |
|---|---|---|---|
| 1 | AT SecurityInfos with a single PACEInfo (ECDH-GM-128) | pass | pass |
| 2 | DE SecurityInfos with two PACEInfos (GM + CAM) — prefers CAM | fail (picked GM) | pass |
| 3 | SecurityInfos with TerminalAuthenticationInfo before PACEInfo (issue #120) | fail (throws) | pass |
| 4 | Real-world DE SecurityInfos (CardSecurity) with mixed types | fail (throws) | pass |
| 5 | SecurityInfos containing only TerminalAuthenticationInfo | fail (throws) | pass |

Full suite: **80/80 passing** (including all existing `pace_test_ecdh.dart`, `pace_test_dh.dart`, `pace_cam_test.dart` tests that consume `efCardAccess.paceInfo`).