### PR TITLE
Add SonarQube scan to status checks

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -51,6 +51,23 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-environment
+      - name: Build
+        run: flutter pub get
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   build-prototypes-android:
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build
         run: flutter pub get
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,8 @@ sonar.organization=privacybydesign
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Disable C/C++/Objective-C analysis (no compilation database available)
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=privacybydesign_vcmrtd
+sonar.organization=privacybydesign
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=vcmrtd
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add a `sonarqube` job to `status-checks.yml` that runs after lint, using the existing `setup-build-environment` action and `flutter pub get` as the build step before `SonarSource/sonarqube-scan-action@v6`.
- Add `sonar-project.properties` at the repo root configuring `privacybydesign_vcmrtd` / `privacybydesign`.