### PR TITLE
Fix for German passports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 rubyvendor/
+twentyface_flutter/
 
 example/fastlane/.env.default
 example/fastlane/build

--- a/lib/src/com/nfc_provider.dart
+++ b/lib/src/com/nfc_provider.dart
@@ -92,6 +92,16 @@ class NfcProvider extends ComProvider {
     }
   }
 
+  /// Clears internal tag state and forces the plugin to finish any active or
+  /// partially-initialised NFC session. Safe to call even when not connected
+  /// (e.g. after a Dart timeout cancelled a poll future).
+  Future<void> forceCleanup() async {
+    _tag = null;
+    try {
+      await FlutterNfcKit.finish();
+    } catch (_) {}
+  }
+
   @override
   bool isConnected() {
     return _tag != null;

--- a/lib/src/crypto/aes.dart
+++ b/lib/src/crypto/aes.dart
@@ -83,9 +83,17 @@ class AESCipher {
     }
     BaseBlockCipher cipher;
     if (mode == BLOCK_CIPHER_MODE.CBC) {
-      cipher = CBCBlockCipher(_factory())..init(true, ParametersWithIV(KeyParameter(key), iv!));
+      cipher = CBCBlockCipher(_factory())
+        ..init(
+          true,
+          ParametersWithIV(KeyParameter(key), iv!),
+        ); // NOSONAR - CBC without padding is required by ICAO 9303 (PACE data is always block-aligned)
     } else {
-      cipher = ECBBlockCipher(_factory())..init(true, KeyParameter(key)); //ECB mode
+      cipher = ECBBlockCipher(_factory())
+        ..init(
+          true,
+          KeyParameter(key),
+        ); // NOSONAR - ECB used for single-block operations only (e.g. IV computation per ICAO 9303 §4.4.3.5)
     }
 
     //return cipher.process(paddedData);
@@ -119,9 +127,17 @@ class AESCipher {
 
     BaseBlockCipher cipher;
     if (mode == BLOCK_CIPHER_MODE.CBC) {
-      cipher = CBCBlockCipher(_factory())..init(false, ParametersWithIV(KeyParameter(key), iv));
+      cipher = CBCBlockCipher(_factory())
+        ..init(
+          false,
+          ParametersWithIV(KeyParameter(key), iv),
+        ); // NOSONAR - CBC without padding is required by ICAO 9303 (PACE data is always block-aligned)
     } else {
-      cipher = ECBBlockCipher(_factory())..init(false, KeyParameter(key));
+      cipher = ECBBlockCipher(_factory())
+        ..init(
+          false,
+          KeyParameter(key),
+        ); // NOSONAR - ECB used for single-block operations only (e.g. IV computation per ICAO 9303 §4.4.3.5)
     }
     return Uint8List.fromList(_processBlocks(cipher: cipher, data: data).toList());
   }

--- a/lib/src/document_reader.dart
+++ b/lib/src/document_reader.dart
@@ -227,7 +227,15 @@ class DocumentReader<DocType extends DocumentData> extends Notifier<DocumentRead
         await _reconnectionLoop(
           authMethod: method,
           whenConnected: () async {
-            aaSig = await dataGroupReader.activeAuthenticate(stringToUint8List(activeAuthenticationParams.nonce));
+            try {
+              aaSig = await dataGroupReader.activeAuthenticate(stringToUint8List(activeAuthenticationParams.nonce));
+            } on DocumentError catch (e) {
+              if (e.code == StatusWord.invalidInstructionCode) {
+                _addLog("Active Authentication not supported by chip (sw=6D00), skipping");
+                return;
+              }
+              rethrow;
+            }
           },
         );
         if (state is DocumentReaderCancelled) {
@@ -270,15 +278,19 @@ class DocumentReader<DocType extends DocumentData> extends Notifier<DocumentRead
 
   Future<void> _retryConnection() async {
     dataGroupReader.reset();
-    if (nfc.isConnected()) {
-      if (Platform.isIOS) {
+    if (Platform.isIOS) {
+      if (nfc.isConnected()) {
         await nfc.reconnect().timeout(Duration(seconds: 2));
       } else {
-        await nfc.disconnect();
-        await nfc.connect().timeout(Duration(seconds: 2));
+        await nfc.connect().timeout(Duration(seconds: 10));
       }
     } else {
-      await nfc.connect().timeout(Duration(seconds: 2));
+      // On Android, always force-finish the plugin session before re-polling.
+      // After a TagLostException the Dart timeout may cancel poll() while the
+      // plugin still holds a stale IsoDep; calling forceCleanup() prevents
+      // subsequent connect/transceive calls from failing with IOException.
+      await nfc.forceCleanup();
+      await nfc.connect().timeout(Duration(seconds: 10));
     }
   }
 

--- a/lib/src/proto/ecdh_pace.dart
+++ b/lib/src/proto/ecdh_pace.dart
@@ -240,7 +240,8 @@ class ECDHPace {
       _log.error("Public key has no parameters (as BigInteger). Something went wrong in PC library.");
       throw ECDHPaceError("Public key has no parameters(as BigInteger). Something went wrong in PC library.");
     }
-    return PublicKeyPACEeCDH(x: x, y: y);
+    final coordLen = (selectedDomainParameter.size + 7) ~/ 8;
+    return PublicKeyPACEeCDH(x: x, y: y, coordLen: coordLen);
   }
 
   PublicKeyPACEeCDH getPubKeyEphemeral() {
@@ -259,7 +260,8 @@ class ECDHPace {
       _log.error("Public ephemeral key has no parameters (as BigInteger). Something went wrong in PC library.");
       throw ECDHPaceError("Public ephemeral key has no parameters(as BigInteger). Something went wrong in PC library.");
     }
-    return PublicKeyPACEeCDH(x: x, y: y);
+    final coordLen = (selectedDomainParameter.size + 7) ~/ 8;
+    return PublicKeyPACEeCDH(x: x, y: y, coordLen: coordLen);
   }
 
   ECPoint getSharedSecret({required ECPublicKey otherPubKey}) {

--- a/lib/src/proto/pace.dart
+++ b/lib/src/proto/pace.dart
@@ -1102,7 +1102,7 @@ class PACE {
       fallback ??= result;
     }
 
-    if (fallback != null) return fallback!;
+    if (fallback != null) return fallback;
     throw PACEError(
       "PACE-CAM: unable to find EC public key for domain parameter $domainParameterId in EF.CardSecurity",
     );

--- a/lib/src/proto/pace.dart
+++ b/lib/src/proto/pace.dart
@@ -2,6 +2,7 @@
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:vcmrtd/extensions.dart';
 import 'package:pointycastle/asn1/primitives/asn1_sequence.dart';
 import 'package:vcmrtd/src/lds/asn1ObjectIdentifiers.dart';
@@ -789,7 +790,7 @@ class PACE {
           }
 
           _log.debug("PACE-CAM: reading EF.CardSecurity over SM ...");
-          final cardSecurityBytes = await _readCardSecurity(icc);
+          final cardSecurityBytes = await readCardSecurity(icc);
           final cardSecurity = EfCardSecurity.fromBytes(cardSecurityBytes);
           final secInfos = cardSecurity.securityInfos;
           if (secInfos == null || secInfos.chipAuthenticationPublicKeyInfos.isEmpty) {
@@ -798,7 +799,7 @@ class PACE {
 
           // Extract PK_IC matching domain parameter ID
           // Matching gmrtd pace.go:421-443 (icPubKeyECForCAM)
-          final pkIc = _extractPkIcForCAM(secInfos.chipAuthenticationPublicKeyInfos, paceDomainParameterId);
+          final pkIc = extractPkIcForCAM(secInfos.chipAuthenticationPublicKeyInfos, paceDomainParameterId);
 
           PaceCam.verifyChipAuthentication(
             encryptedChipAuthData: ecad,
@@ -995,7 +996,8 @@ class PACE {
 
   /// Reads EF.CardSecurity (FID 0x011D) from the chip over secure messaging.
   /// Matching gmrtd pace.go:529-543 (loadCardSecurityFile).
-  static Future<Uint8List> _readCardSecurity(ICC icc) async {
+  @visibleForTesting
+  static Future<Uint8List> readCardSecurity(ICC icc) async {
     _log.debug("Reading EF.CardSecurity (SFI 0x${EfCardSecurity.SFI.toRadixString(16).padLeft(2, '0')}) over SM ...");
 
     // Use SFI-based READ BINARY (P1 = 0x80 | SFI) — no SELECT FILE command needed.
@@ -1041,7 +1043,8 @@ class PACE {
   /// keyId matches [domainParameterId] is preferred (BSI TR-03110 §4.2.3.3).
   /// This correctly selects the CAM-specific key on passports that also carry
   /// a separate GM chip-authentication key (different keyId).
-  static ({Uint8List x, Uint8List y}) _extractPkIcForCAM(
+  @visibleForTesting
+  static ({Uint8List x, Uint8List y}) extractPkIcForCAM(
     List<ChipAuthenticationPublicKeyInfo> caPubKeyInfos,
     int domainParameterId,
   ) {

--- a/lib/src/proto/pace.dart
+++ b/lib/src/proto/pace.dart
@@ -996,31 +996,37 @@ class PACE {
   /// Reads EF.CardSecurity (FID 0x011D) from the chip over secure messaging.
   /// Matching gmrtd pace.go:529-543 (loadCardSecurityFile).
   static Future<Uint8List> _readCardSecurity(ICC icc) async {
-    _log.debug("Reading EF.CardSecurity (FID 0x011D) ...");
-    final efId = Uint8List(2);
-    ByteData.view(efId.buffer).setUint16(0, EfCardSecurity.FID);
-    await icc.selectEF(efId: efId);
+    _log.debug("Reading EF.CardSecurity (SFI 0x${EfCardSecurity.SFI.toRadixString(16).padLeft(2, '0')}) over SM ...");
 
-    // Read initial chunk to determine file length
-    final chunk1 = await icc.readBinary(offset: 0, ne: 256);
+    // Use SFI-based READ BINARY (P1 = 0x80 | SFI) — no SELECT FILE command needed.
+    // German passports reject SELECT FILE for EF.CardSecurity over SM (sw=6A80),
+    // but accept SFI-based READ BINARY which implicitly selects the EF.
+    // This mirrors MrtdApi.readFileBySFI used for EF.CardAccess.
+    final sfiP1 = 0x80 | EfCardSecurity.SFI;
+    _log.debug("_readCardSecurity: reading first chunk via SFI READ BINARY (P1=0x${sfiP1.toRadixString(16)})");
+    final chunk1 = await icc.readBinaryBySFI(sfi: sfiP1, offset: 0, ne: 256);
+    _log.debug("_readCardSecurity: chunk1 status=${chunk1.status} len=${chunk1.data?.length ?? 0}");
     if (chunk1.data == null || chunk1.data!.isEmpty) {
       throw PACEError("PACE-CAM: Failed to read EF.CardSecurity");
     }
 
     final dtl = TLV.decodeTagAndLength(chunk1.data!);
     final totalLen = dtl.encodedLen + dtl.length.value;
+    _log.debug("_readCardSecurity: totalLen=$totalLen (encodedLen=${dtl.encodedLen} + valueLen=${dtl.length.value})");
 
-    // Read remaining chunks
+    // Read remaining chunks — file is now implicitly selected by the SFI read
     var data = Uint8List.fromList(chunk1.data!);
     while (data.length < totalLen) {
       final remaining = totalLen - data.length;
       final nRead = remaining > 256 ? 256 : remaining;
+      _log.debug("_readCardSecurity: reading chunk at offset=${data.length} nRead=$nRead remaining=$remaining");
       final ResponseAPDU chunk;
       if (data.length > 0x7FFF) {
         chunk = await icc.readBinaryExt(offset: data.length, ne: nRead);
       } else {
         chunk = await icc.readBinary(offset: data.length, ne: nRead);
       }
+      _log.debug("_readCardSecurity: chunk status=${chunk.status} len=${chunk.data?.length ?? 0}");
       if (chunk.data == null || chunk.data!.isEmpty) break;
       data = Uint8List.fromList(data + chunk.data!);
     }
@@ -1028,13 +1034,19 @@ class PACE {
     return data;
   }
 
-  /// Extracts the chip's static EC public key (PK_IC) from ChipAuthenticationPublicKeyInfo
-  /// entries, matching the given domain parameter ID.
-  /// Matching gmrtd pace.go:421-443 (icPubKeyECForCAM).
+  /// Extracts the chip's static EC public key (PK_IC) for PACE-CAM from
+  /// ChipAuthenticationPublicKeyInfo entries.
+  ///
+  /// When multiple entries share the same domain parameter, the entry whose
+  /// keyId matches [domainParameterId] is preferred (BSI TR-03110 §4.2.3.3).
+  /// This correctly selects the CAM-specific key on passports that also carry
+  /// a separate GM chip-authentication key (different keyId).
   static ({Uint8List x, Uint8List y}) _extractPkIcForCAM(
     List<ChipAuthenticationPublicKeyInfo> caPubKeyInfos,
     int domainParameterId,
   ) {
+    ({Uint8List x, Uint8List y})? fallback;
+
     for (final info in caPubKeyInfos) {
       // Only evaluate EC keys (protocol == id-PK-ECDH)
       if (info.protocol != '0.4.0.127.0.7.2.2.1.2') continue;
@@ -1081,8 +1093,16 @@ class PACE {
       final coordLen = (keyBytes.length - 1) ~/ 2;
       final x = Uint8List.fromList(keyBytes.sublist(1, 1 + coordLen));
       final y = Uint8List.fromList(keyBytes.sublist(1 + coordLen));
-      return (x: x, y: y);
+      final result = (x: x, y: y);
+
+      // Prefer the entry whose keyId matches the PACE domain parameter ID
+      // (BSI TR-03110 §4.2.3.3: PACE-CAM key has keyId == PACE paramId).
+      if (info.keyId == domainParameterId) return result;
+
+      fallback ??= result;
     }
+
+    if (fallback != null) return fallback!;
     throw PACEError(
       "PACE-CAM: unable to find EC public key for domain parameter $domainParameterId in EF.CardSecurity",
     );

--- a/lib/src/proto/public_key_pace.dart
+++ b/lib/src/proto/public_key_pace.dart
@@ -30,7 +30,10 @@ class PublicKeyPACEeCDH extends PublicKeyPACE {
   final int _coordLen;
 
   PublicKeyPACEeCDH({required BigInt x, required BigInt y, int coordLen = 0})
-    : _x = x, _y = y, _coordLen = coordLen, super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
+    : _x = x,
+      _y = y,
+      _coordLen = coordLen,
+      super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
 
   PublicKeyPACEeCDH.fromECPoint({required ECPoint public})
     : _x = public.x!.toBigInteger()!,

--- a/lib/src/proto/public_key_pace.dart
+++ b/lib/src/proto/public_key_pace.dart
@@ -25,18 +25,32 @@ abstract class PublicKeyPACE {
 class PublicKeyPACEeCDH extends PublicKeyPACE {
   final BigInt _x;
   final BigInt _y;
-  PublicKeyPACEeCDH({required BigInt x, required BigInt y}) : _x = x, _y = y, super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
+  // Coordinate byte length for the curve (0 = no padding). Must be set for
+  // terminal-generated keys so coordinates are padded to the curve field size.
+  final int _coordLen;
+
+  PublicKeyPACEeCDH({required BigInt x, required BigInt y, int coordLen = 0})
+    : _x = x, _y = y, _coordLen = coordLen, super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
 
   PublicKeyPACEeCDH.fromECPoint({required ECPoint public})
     : _x = public.x!.toBigInteger()!,
       _y = public.y!.toBigInteger()!,
+      _coordLen = 0,
       super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
 
   BigInt get x => _x;
   BigInt get y => _y;
 
-  Uint8List get xBytes => Utils.bigIntToUint8List(bigInt: _x);
-  Uint8List get yBytes => Utils.bigIntToUint8List(bigInt: _y);
+  Uint8List _paddedCoord(BigInt coord) {
+    final raw = Utils.bigIntToUint8List(bigInt: coord);
+    if (_coordLen <= 0 || raw.length >= _coordLen) return raw;
+    final padded = Uint8List(_coordLen);
+    padded.setRange(_coordLen - raw.length, _coordLen, raw);
+    return padded;
+  }
+
+  Uint8List get xBytes => _paddedCoord(_x);
+  Uint8List get yBytes => _paddedCoord(_y);
 
   @override
   Uint8List toBytes() {
@@ -46,6 +60,7 @@ class PublicKeyPACEeCDH extends PublicKeyPACE {
   PublicKeyPACEeCDH.fromHex({required Uint8List hexKey})
     : _x = Utils.uint8ListToBigInt(hexKey.sublist(0, hexKey.length ~/ 2)),
       _y = Utils.uint8ListToBigInt(hexKey.sublist(hexKey.length ~/ 2)),
+      _coordLen = 0,
       super(algo: TOKEN_AGREEMENT_ALGO.ECDH);
 
   @override

--- a/test/efcard_security_test.dart
+++ b/test/efcard_security_test.dart
@@ -43,6 +43,55 @@ void main() {
       }
     });
 
+    // Verifies the keyId field is correctly parsed for both entries.
+    // Per BSI TR-03110 §4.2.3.3, the CAM key has keyId == PACE domainParameterId.
+    // For this DE passport the PACE domain parameter is 13 (BrainpoolP256r1),
+    // so the CAM key must have keyId=13 and the GM key must have keyId=72.
+    // This was the root cause of the PACE-CAM bug: the wrong key (keyId=72) was
+    // selected because the code ignored keyId.
+    test('chipAuthPublicKeyInfos carry correct keyIds (13 for CAM, 72 for GM)', () {
+      final ef = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex());
+      final si = ef.securityInfos!;
+
+      final keyIds = si.chipAuthenticationPublicKeyInfos.map((k) => k.keyId).toSet();
+      expect(keyIds, containsAll([13, 72]), reason: 'DE passport must have keyId=13 (CAM) and keyId=72 (GM)');
+    });
+
+    // Verifies that the key with keyId=13 carries the expected CAM public key.
+    // X coordinate starts 614CD88B… (from gmrtd TestNewCardSecurityDE).
+    test('key with keyId=13 (CAM) has expected public key X coordinate', () {
+      final ef = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex());
+      final si = ef.securityInfos!;
+
+      final camKey = si.chipAuthenticationPublicKeyInfos.firstWhere((k) => k.keyId == 13);
+
+      // SubjectPublicKeyInfo → BIT STRING → 04 ‖ X (32 bytes) ‖ Y (32 bytes)
+      // valueBytes on the BIT STRING element skips the tag+length, leaving the raw bit-string value.
+      // The first byte of the value is the "unused bits" count (always 0 for keys), then 04‖X‖Y.
+      final keyElement = camKey.chipAuthenticationPublicKey.elements![1];
+      final keyBytes = keyElement.valueBytes!;
+      // valueBytes includes the unused-bits byte (0x00) before the EC point.
+      final pointStart = keyBytes[0] == 0x00 ? 1 : 0;
+      expect(keyBytes[pointStart], 0x04, reason: 'uncompressed-point marker');
+      final xCoord = keyBytes.sublist(pointStart + 1, pointStart + 33).map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      expect(xCoord.toLowerCase(), startsWith('614cd88b'), reason: 'X must match gmrtd test vector');
+    });
+
+    // Verifies that the key with keyId=72 carries a different public key than keyId=13,
+    // confirming that selecting the wrong key would produce an incorrect result.
+    test('key with keyId=72 (GM) has a different public key than keyId=13', () {
+      final ef = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex());
+      final si = ef.securityInfos!;
+
+      final camKey = si.chipAuthenticationPublicKeyInfos.firstWhere((k) => k.keyId == 13);
+      final gmKey = si.chipAuthenticationPublicKeyInfos.firstWhere((k) => k.keyId == 72);
+
+      final camBits = camKey.chipAuthenticationPublicKey.elements![1].valueBytes!;
+      final gmBits = gmKey.chipAuthenticationPublicKey.elements![1].valueBytes!;
+
+      expect(camBits, isNot(equals(gmBits)), reason: 'CAM and GM keys must be distinct');
+    });
+
     // Verifies that malformed input (not a CMS SignedData) does not crash;
     // parse returns silently with securityInfos == null.
     test('returns null securityInfos for malformed input', () {

--- a/test/efcard_security_test.dart
+++ b/test/efcard_security_test.dart
@@ -73,7 +73,10 @@ void main() {
       // valueBytes includes the unused-bits byte (0x00) before the EC point.
       final pointStart = keyBytes[0] == 0x00 ? 1 : 0;
       expect(keyBytes[pointStart], 0x04, reason: 'uncompressed-point marker');
-      final xCoord = keyBytes.sublist(pointStart + 1, pointStart + 33).map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      final xCoord = keyBytes
+          .sublist(pointStart + 1, pointStart + 33)
+          .map((b) => b.toRadixString(16).padLeft(2, '0'))
+          .join();
       expect(xCoord.toLowerCase(), startsWith('614cd88b'), reason: 'X must match gmrtd test vector');
     });
 

--- a/test/pace_cam_im_regression_test.dart
+++ b/test/pace_cam_im_regression_test.dart
@@ -1,6 +1,7 @@
 // Regression tests for PACE-CAM and PACE-IM bugs.
 // Also tested in gmrtd: pace/pace_test.go, pace/pace.go
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
@@ -10,10 +11,39 @@ import 'package:vcmrtd/extensions.dart';
 import 'package:vcmrtd/src/com/com_provider.dart';
 import 'package:vcmrtd/src/lds/asn1ObjectIdentifiers.dart';
 import 'package:vcmrtd/src/lds/efcard_access.dart';
+import 'package:vcmrtd/src/lds/efcard_security.dart';
 import 'package:vcmrtd/src/proto/dba_key.dart';
 import 'package:vcmrtd/src/proto/iso7816/icc.dart';
 import 'package:vcmrtd/src/proto/pace.dart';
 import 'package:vcmrtd/src/proto/pace_cam.dart';
+
+/// Replays scripted APDU responses in order; also records every sent APDU.
+/// Returns 6A80 after all scripted responses are exhausted.
+class _ScriptedComProvider extends ComProvider {
+  final List<Uint8List> _responses;
+  final List<Uint8List> sentApdus = [];
+  int _idx = 0;
+
+  _ScriptedComProvider(List<String> hexResponses)
+    : _responses = hexResponses.map((h) => h.parseHex()).toList(),
+      super(Logger('_ScriptedComProvider'));
+
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Future<void> reconnect() async {}
+  @override
+  bool isConnected() => true;
+
+  @override
+  Future<Uint8List> transceive(Uint8List data) async {
+    sentApdus.add(Uint8List.fromList(data));
+    if (_idx >= _responses.length) return Uint8List.fromList([0x6A, 0x80]);
+    return _responses[_idx++];
+  }
+}
 
 /// Records every APDU sent during PACE, returns 6A80 for each.
 class _RecordingComProvider extends ComProvider {
@@ -185,6 +215,105 @@ void main() {
         ),
         throwsA(isA<PaceCamError>()),
       );
+    });
+  });
+
+  // Real German ePassport EF.CardSecurity (same data as efcard_security_test.dart).
+  // Contains TWO ChipAuthenticationPublicKeyInfos:
+  //   keyId=13 (CAM key, X=614CD88B…) and keyId=72 (GM key, X=8488A2DC…).
+  const deCardSecurityHex =
+      '3082074206092A864886F70D010702A08207333082072F020103310F300D0609608648016503040202050030820147060804007F0007030201A08201390482013531820131300D060804007F00070202020201023012060A04007F000702020302020201020201483012060A04007F0007020204020202010202010D3012060A04007F0007020204060202010202010D301C060904007F000702020302300C060704007F0007010202010D0201483062060904007F0007020201023052300C060704007F0007010202010D03420004614CD88B00821A887869D0060B44A9D18789353E8CF7DFBC3F29F79327DE30B97B1B2DDA0BE77F24AD415C327C7B7AB2E9C10B0258F5BCBF90C01825FBDFDEF702010D3062060904007F0007020201023052300C060704007F0007010202010D034200048488A2DC34B6B36D6C01A8DFBD70A874610C53B32893A1DE3B1C4BBF477EEF3761AA51DFD6B52DA43587E95386FC34FFE178D90086A7D646047C82BEBC27DA3E020148A082049730820493308203F8A003020102020204A8300A06082A8648CE3D0403043041310B3009060355040613024445310D300B060355040A0C0462756E64310C300A060355040B0C036273693115301306035504030C0C637363612D6765726D616E79301E170D3233303130343036303434325A170D3333303730343233353935395A305D310B3009060355040613024445311D301B060355040A0C1442756E646573647275636B6572656920476D6248310C300A060355040513033135323121301F06035504030C18446F63756D656E74205369676E65722050617373706F7274308201B53082014D06072A8648CE3D020130820140020101303C06072A8648CE3D01010231008CB91E82A3386D280F5D6F7E50E641DF152F7109ED5456B412B1DA197FB71123ACD3A729901D1A71874700133107EC53306404307BC382C63D8C150C3C72080ACE05AFA0C2BEA28E4FB22787139165EFBA91F90F8AA5814A503AD4EB04A8C7DD22CE2826043004A8C7DD22CE28268B39B55416F0447C2FB77DE107DCD2A62E880EA53EEB62D57CB4390295DBC9943AB78696FA504C110461041D1C64F068CF45FFA2A63A81B7C13F6B8847A3E77EF14FE3DB7FCAFE0CBD10E8E826E03436D646AAEF87B2E247D4AF1E8ABE1D7520F9C2A45CB1EB8E95CFD55262B70B29FEEC5864E19C054FF99129280E4646217791811142820341263C53150231008CB91E82A3386D280F5D6F7E50E641DF152F7109ED5456B31F166E6CAC0425A7CF3AB6AF6B7FC3103B883202E9046565020101036200042CA852CB9A1CAAAA466256D1CFD678BB7E5D8502DFA6F3FDB287293C32AF9FA77AD3A7FA92E56F608110053121354002198B530BC60AC7050AB98D7F6C475FD50706A4A6207D7A6336CB480B966A3AA64894F7F42B8FB4AC4774C9D6892330FBA382016430820160301F0603551D23041830168014A40A5FC380AE3E59AF1B32D6136AEFEEC8CA35E8301D0603551D0E04160414AF9DD5E6565737A8804B5B4C6F45093D809AA865300E0603551D0F0101FF040403020780302B0603551D1004243022800F32303233303130343036303434325A810F32303233303730343233353935395A30160603551D20040F300D300B060904007F000703010101302D0603551D1104263024821262756E646573647275636B657265692E6465A40E300C310A300806035504070C014430510603551D12044A30488118637363612D6765726D616E79406273692E62756E642E6465861C68747470733A2F2F7777772E6273692E62756E642E64652F63736361A40E300C310A300806035504070C01443015060767810801010602040A3008020100310313015030300603551D1F042930273025A023A021861F687474703A2F2F7777772E6273692E62756E642E64652F637363615F63726C300A06082A8648CE3D0403040381880030818402404846F4A03E17896E9094AF7652C38FE31EC964C2C3A906AF813AABEF5FE4F3156D140E2EF991DC11FD860A4A301B225DE9FD4ED39B4F47AC72CDB88CC63B335902405D4E2895875E603CE2863073BF441D1EC53761CF47E5BC2B9B6BECE4F229712E39002D77B555290FA550DF5F40AA22D7D2A1E89FEB3FEF730AE33C937796E8E3318201313082012D02010130473041310B3009060355040613024445310D300B060355040A0C0462756E64310C300A060355040B0C036273693115301306035504030C0C637363612D6765726D616E79020204A8300D06096086480165030402020500A05A301706092A864886F70D010903310A060804007F0007030201303F06092A864886F70D010904313204300FF966AB1283D22A0046338B734FBAE653622C15FE7538392E0987D87BEE0AB009BA77506E45D964B138E688BE8DA60D300C06082A8648CE3D040303050004663064023025FDE09B7F60E9B8F57413427128E6B9ED29C252E396D0F699A84B90247BDBDCA66BDA66A319423EB1D95D206E6BDAE8023016D075859D63301201E925A55ACCC7D3BC1E4C0457A87F5575821C6345FF1C059DEEF935E8125EA948BAAC7A9EF97199';
+
+  // Also tested in gmrtd: pace/pace.go:489 (icPubKeyECForCAM)
+  group('PACE.extractPkIcForCAM key selection (BSI TR-03110 §4.2.3.3)', () {
+    // Verifies the keyId-match path: DE passport has keyId=13 (CAM) and keyId=72 (GM).
+    // When domainParameterId=13, the entry with keyId=13 must be returned.
+    test('prefers entry whose keyId equals the PACE domain parameter ID', () {
+      final si = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex()).securityInfos!;
+      final pkIc = PACE.extractPkIcForCAM(si.chipAuthenticationPublicKeyInfos, 13);
+      final xHex = pkIc.x.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      expect(xHex, startsWith('614cd88b'), reason: 'must return CAM key (keyId=13), not GM key (keyId=72)');
+    });
+
+    // Verifies the fallback path: single-key passports that have no keyId matching
+    // the domain parameter still get their only EC key returned.
+    // Also tested in gmrtd: pace/pace.go fallback logic.
+    test('falls back to first valid EC key when no keyId matches', () {
+      final si = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex()).securityInfos!;
+      // Use only the keyId=72 (GM) entry — no exact keyId match for domainParam=13.
+      final gmKeyOnly = si.chipAuthenticationPublicKeyInfos.where((k) => k.keyId == 72).toList();
+      final pkIc = PACE.extractPkIcForCAM(gmKeyOnly, 13);
+      final xHex = pkIc.x.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      expect(xHex, startsWith('8488a2dc'), reason: 'fallback must return the only available EC key');
+    });
+
+    // Verifies that a mismatched domain parameter produces a clear error rather than
+    // silently returning a key for the wrong curve.
+    test('throws PACEError when no entry matches the requested domain parameter', () {
+      final si = EfCardSecurity.fromBytes(deCardSecurityHex.parseHex()).securityInfos!;
+      expect(
+        () => PACE.extractPkIcForCAM(si.chipAuthenticationPublicKeyInfos, 99),
+        throwsA(isA<PACEError>()),
+        reason: 'paramId=99 does not exist in DE CardSecurity',
+      );
+    });
+
+    test('throws PACEError for an empty key list', () {
+      expect(() => PACE.extractPkIcForCAM([], 13), throwsA(isA<PACEError>()));
+    });
+  });
+
+  // Also tested in gmrtd: pace/pace.go:529-543 (loadCardSecurityFile).
+  group('PACE.readCardSecurity SFI-based reading (German passport fix)', () {
+    // Verifies the first READ BINARY uses SFI P1=0x9D instead of a SELECT FILE
+    // followed by offset-0 READ BINARY. German passports reject SELECT FILE for
+    // EF.CardSecurity over secure messaging (sw=6A80).
+    test('first READ BINARY uses SFI P1=0x9D (no SELECT FILE)', () async {
+      // Minimal valid TLV that fits in one 256-byte chunk.
+      final tinyData = Uint8List.fromList([0x30, 0x04, 0x01, 0x02, 0x03, 0x04]);
+      final com = _ScriptedComProvider(['${tinyData.map((b) => b.toRadixString(16).padLeft(2, '0')).join()}9000']);
+      final icc = ICC(com);
+
+      await PACE.readCardSecurity(icc);
+
+      expect(com.sentApdus, isNotEmpty);
+      final firstApdu = com.sentApdus.first;
+      // INS must be READ BINARY (0xB0), not SELECT FILE (0xA4).
+      expect(firstApdu[1], 0xB0, reason: 'INS must be READ BINARY');
+      // P1 must be the SFI selector: 0x80 | EfCardSecurity.SFI (0x1D) = 0x9D.
+      expect(firstApdu[2], 0x80 | EfCardSecurity.SFI, reason: 'P1 must use SFI encoding');
+      // No SELECT FILE (INS=0xA4) may appear before the first READ BINARY.
+      final hasSelectFile = com.sentApdus.any((apdu) => apdu[1] == 0xA4);
+      expect(hasSelectFile, isFalse, reason: 'SELECT FILE must not be sent before SFI READ BINARY');
+    });
+
+    // Verifies that a multi-chunk file is assembled correctly from successive
+    // READ BINARY responses (offset-based reads after the first SFI read).
+    test('reassembles multi-chunk EF.CardSecurity correctly', () async {
+      final deBytes = deCardSecurityHex.parseHex();
+      // Split into 256-byte chunks, each followed by status 9000.
+      final responses = <String>[];
+      for (int offset = 0; offset < deBytes.length; offset += 256) {
+        final end = min(offset + 256, deBytes.length);
+        final chunk = deBytes.sublist(offset, end);
+        responses.add('${chunk.map((b) => b.toRadixString(16).padLeft(2, '0')).join()}9000');
+      }
+
+      final com = _ScriptedComProvider(responses);
+      final icc = ICC(com);
+      final result = await PACE.readCardSecurity(icc);
+
+      expect(result, deBytes, reason: 'reassembled bytes must equal the original DE CardSecurity');
+    });
+
+    // Verifies that an empty (or error) first response produces a clean PACEError
+    // rather than a NullPointerException or ICCError bubbling up to the caller.
+    test('throws PACEError when chip returns empty data for first chunk', () async {
+      // Return 9000 with no data — triggers the "Failed to read EF.CardSecurity" guard.
+      final com = _ScriptedComProvider(['9000']);
+      final icc = ICC(com);
+
+      expect(() => PACE.readCardSecurity(icc), throwsA(isA<PACEError>()));
     });
   });
 }

--- a/test/pace_cam_im_regression_test.dart
+++ b/test/pace_cam_im_regression_test.dart
@@ -15,6 +15,33 @@ import 'package:vcmrtd/src/proto/iso7816/icc.dart';
 import 'package:vcmrtd/src/proto/pace.dart';
 import 'package:vcmrtd/src/proto/pace_cam.dart';
 
+// Scripted mock: replays fixed APDU responses in insertion order.
+class _ScriptedComProvider extends ComProvider {
+  final List<Uint8List> _responses;
+  int _idx = 0;
+
+  _ScriptedComProvider(List<String> hexResponses)
+    : _responses = hexResponses.map((h) => h.parseHex()).toList(),
+      super(Logger('_ScriptedComProvider'));
+
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Future<void> reconnect() async {}
+  @override
+  bool isConnected() => true;
+
+  @override
+  Future<Uint8List> transceive(Uint8List data) async {
+    if (_idx >= _responses.length) {
+      return Uint8List.fromList([0x6A, 0x80]);
+    }
+    return _responses[_idx++];
+  }
+}
+
 /// Records every APDU sent during PACE, returns 6A80 for each.
 class _RecordingComProvider extends ComProvider {
   final List<Uint8List> sentApdus = [];
@@ -104,6 +131,68 @@ void main() {
       final mseHex = com.sentApdus.first.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
       final camOidHex = '04007f00070202040602'.parseHex().map((b) => b.toRadixString(16).padLeft(2, '0')).join();
       expect(mseHex.contains(camOidHex), isTrue);
+    });
+
+    // Test vectors from gmrtd TestDoPace_CAM_ECDH_DE.
+    // The DE passport EF.CardSecurity has TWO ChipAuthenticationPublicKeyInfos:
+    //   keyId=13  →  CAM key  (must be used, X starts 614CD88B…)
+    //   keyId=72  →  GM key   (must NOT be used, X starts 8488A2DC…)
+    // Per BSI TR-03110 §4.2.3.3, the correct key is the one whose
+    // keyId equals the PACE domain-parameter ID (13 = BrainpoolP256r1).
+    //
+    // This test directly exercises the fix in _extractPkIcForCAM: using the
+    // wrong key (keyId=72) must produce a failing verification, while the
+    // correct key (keyId=13) must produce a passing one.
+    test('CAM verification passes with keyId=13 and fails with keyId=72 (DE passport vectors)', () {
+      // Session encryption key and ECAD from gmrtd TestDoPace_CAM_ECDH_DE step-4.
+      final ksEnc = 'a8e85e938514ec67ae33cda3d43d3c48'.parseHex();
+      final ecad =
+          'b3ae8830311b1d5605777f47cb4ed028346cd00105d32859de127da3d8398865358f26f08ebe410864eaf6e39f33f3f5'
+              .parseHex();
+
+      // PKMap_IC = chip's ephemeral public key from PACE Map Nonce step (tag 82 in gmrtd mock).
+      // This is from the Map Nonce response, NOT the Key Agreement response (tag 84).
+      // gmrtd mapNonceGmEcDh returns pubMapIC = decodeDynAuthData(0x82, ...).
+      final pkMapIcX = '76dc295c4fb14237d87318d70967e25ec45f74d6fd4aff588c90efb3d868f05b'.parseHex();
+      final pkMapIcY = '450ba6b64967227c2246dbe2905522c8086dac7f3bbe5cf3b192f0a0c2d97ee5'.parseHex();
+
+      // Correct CA key from DE CardSecurity: keyId=13.
+      final pkIcCamX = '614CD88B00821A887869D0060B44A9D18789353E8CF7DFBC3F29F79327DE30B9'.parseHex();
+      final pkIcCamY = '7B1B2DDA0BE77F24AD415C327C7B7AB2E9C10B0258F5BCBF90C01825FBDFDEF7'.parseHex();
+
+      // Wrong CA key from DE CardSecurity: keyId=72 (GM key — previously returned by the bug).
+      final pkIcGmX = '8488A2DC34B6B36D6C01A8DFBD70A874610C53B32893A1DE3B1C4BBF477EEF37'.parseHex();
+      final pkIcGmY = '61AA51DFD6B52DA43587E95386FC34FFE178D90086A7D646047C82BEBC27DA3E'.parseHex();
+
+      expect(
+        PaceCam.verifyChipAuthentication(
+          encryptedChipAuthData: ecad,
+          ksEnc: ksEnc,
+          keyLength: KEY_LENGTH.s128,
+          pkIcX: pkIcCamX,
+          pkIcY: pkIcCamY,
+          pkMapIcX: pkMapIcX,
+          pkMapIcY: pkMapIcY,
+          domainParameterId: 13,
+        ),
+        isTrue,
+        reason: 'correct key (keyId=13) must pass CAM verification',
+      );
+
+      expect(
+        () => PaceCam.verifyChipAuthentication(
+          encryptedChipAuthData: ecad,
+          ksEnc: ksEnc,
+          keyLength: KEY_LENGTH.s128,
+          pkIcX: pkIcGmX,
+          pkIcY: pkIcGmY,
+          pkMapIcX: pkMapIcX,
+          pkMapIcY: pkMapIcY,
+          domainParameterId: 13,
+        ),
+        throwsA(isA<PaceCamError>()),
+        reason: 'wrong key (keyId=72) must fail CAM verification — was the pre-fix behaviour',
+      );
     });
 
     // Also tested in gmrtd: pace/pace_test.go:690 (TestDoCamEcdhMappingNoEcadIcErr)

--- a/test/pace_cam_im_regression_test.dart
+++ b/test/pace_cam_im_regression_test.dart
@@ -15,33 +15,6 @@ import 'package:vcmrtd/src/proto/iso7816/icc.dart';
 import 'package:vcmrtd/src/proto/pace.dart';
 import 'package:vcmrtd/src/proto/pace_cam.dart';
 
-// Scripted mock: replays fixed APDU responses in insertion order.
-class _ScriptedComProvider extends ComProvider {
-  final List<Uint8List> _responses;
-  int _idx = 0;
-
-  _ScriptedComProvider(List<String> hexResponses)
-    : _responses = hexResponses.map((h) => h.parseHex()).toList(),
-      super(Logger('_ScriptedComProvider'));
-
-  @override
-  Future<void> connect() async {}
-  @override
-  Future<void> disconnect() async {}
-  @override
-  Future<void> reconnect() async {}
-  @override
-  bool isConnected() => true;
-
-  @override
-  Future<Uint8List> transceive(Uint8List data) async {
-    if (_idx >= _responses.length) {
-      return Uint8List.fromList([0x6A, 0x80]);
-    }
-    return _responses[_idx++];
-  }
-}
-
 /// Records every APDU sent during PACE, returns 6A80 for each.
 class _RecordingComProvider extends ComProvider {
   final List<Uint8List> sentApdus = [];

--- a/test/pace_cam_im_regression_test.dart
+++ b/test/pace_cam_im_regression_test.dart
@@ -146,9 +146,8 @@ void main() {
     test('CAM verification passes with keyId=13 and fails with keyId=72 (DE passport vectors)', () {
       // Session encryption key and ECAD from gmrtd TestDoPace_CAM_ECDH_DE step-4.
       final ksEnc = 'a8e85e938514ec67ae33cda3d43d3c48'.parseHex();
-      final ecad =
-          'b3ae8830311b1d5605777f47cb4ed028346cd00105d32859de127da3d8398865358f26f08ebe410864eaf6e39f33f3f5'
-              .parseHex();
+      final ecad = 'b3ae8830311b1d5605777f47cb4ed028346cd00105d32859de127da3d8398865358f26f08ebe410864eaf6e39f33f3f5'
+          .parseHex();
 
       // PKMap_IC = chip's ephemeral public key from PACE Map Nonce step (tag 82 in gmrtd mock).
       // This is from the Map Nonce response, NOT the Key Agreement response (tag 84).

--- a/test/public_key_pace_test.dart
+++ b/test/public_key_pace_test.dart
@@ -18,7 +18,7 @@ void main() {
     test('xBytes is zero-padded when BigInt representation is shorter than coordLen', () {
       // A 256-bit coordinate whose top byte is 0x00 encodes as only 31 bytes
       // when using BigInt.toRadixString. coordLen=32 must restore the full width.
-      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final xBigInt = BigInt.parse('00${'AB' * 31}', radix: 16);
       final yBigInt = BigInt.parse('FF' * 32, radix: 16);
 
       final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
@@ -30,7 +30,7 @@ void main() {
 
     test('yBytes is zero-padded when BigInt representation is shorter than coordLen', () {
       final xBigInt = BigInt.parse('FF' * 32, radix: 16);
-      final yBigInt = BigInt.parse('00' + 'CD' * 31, radix: 16);
+      final yBigInt = BigInt.parse('00${'CD' * 31}', radix: 16);
 
       final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
 
@@ -52,7 +52,7 @@ void main() {
     test('coordLen=0 disables padding (backward-compatibility default)', () {
       // When no coordLen is supplied the constructor defaults to 0 and returns
       // the raw BigInt byte representation (no zero-padding).
-      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final xBigInt = BigInt.parse('00${'AB' * 31}', radix: 16);
       final yBigInt = BigInt.parse('FF' * 32, radix: 16);
 
       final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt);
@@ -91,7 +91,7 @@ void main() {
       // Uncompressed EC point encoding: 04 || X (coordLen bytes) || Y (coordLen bytes)
       // If X has a leading-zero byte that BigInt drops, the encoded point must still
       // start with 04 and have exactly 1 + 2*coordLen bytes total.
-      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final xBigInt = BigInt.parse('00${'AB' * 31}', radix: 16);
       final yBigInt = BigInt.parse('CD' * 32, radix: 16);
 
       final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);

--- a/test/public_key_pace_test.dart
+++ b/test/public_key_pace_test.dart
@@ -1,0 +1,105 @@
+// Tests for PublicKeyPACEeCDH coordinate zero-padding.
+// Ported from gmrtd (https://github.com/gmrtd/gmrtd).
+//
+// EC coordinates from a BigInt may be shorter than the curve's field size
+// when the leading byte is 0x00. Without padding, the encoded uncompressed
+// point 04‖X‖Y would be malformed and rejected by the chip.
+
+import 'dart:typed_data';
+import 'package:test/test.dart';
+import 'package:vcmrtd/src/proto/public_key_pace.dart';
+
+void main() {
+  group('PublicKeyPACEeCDH coordinate padding', () {
+    // -------------------------------------------------------------------
+    // Core padding behaviour
+    // -------------------------------------------------------------------
+
+    test('xBytes is zero-padded when BigInt representation is shorter than coordLen', () {
+      // A 256-bit coordinate whose top byte is 0x00 encodes as only 31 bytes
+      // when using BigInt.toRadixString. coordLen=32 must restore the full width.
+      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final yBigInt = BigInt.parse('FF' * 32, radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
+
+      expect(pubKey.xBytes.length, 32, reason: 'xBytes must be padded to coordLen');
+      expect(pubKey.xBytes[0], 0x00, reason: 'leading zero byte must be preserved');
+      expect(pubKey.xBytes.sublist(1), Uint8List.fromList(List.filled(31, 0xAB)));
+    });
+
+    test('yBytes is zero-padded when BigInt representation is shorter than coordLen', () {
+      final xBigInt = BigInt.parse('FF' * 32, radix: 16);
+      final yBigInt = BigInt.parse('00' + 'CD' * 31, radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
+
+      expect(pubKey.yBytes.length, 32, reason: 'yBytes must be padded to coordLen');
+      expect(pubKey.yBytes[0], 0x00);
+      expect(pubKey.yBytes.sublist(1), Uint8List.fromList(List.filled(31, 0xCD)));
+    });
+
+    test('full-length coordinate is returned unchanged', () {
+      final xBigInt = BigInt.parse('FF' * 32, radix: 16);
+      final yBigInt = BigInt.parse('AB' * 32, radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
+
+      expect(pubKey.xBytes.length, 32);
+      expect(pubKey.yBytes.length, 32);
+    });
+
+    test('coordLen=0 disables padding (backward-compatibility default)', () {
+      // When no coordLen is supplied the constructor defaults to 0 and returns
+      // the raw BigInt byte representation (no zero-padding).
+      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final yBigInt = BigInt.parse('FF' * 32, radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt);
+
+      expect(pubKey.xBytes.length, 31, reason: 'without coordLen the leading zero is absent');
+    });
+
+    // -------------------------------------------------------------------
+    // BrainpoolP256r1 real-world test vectors (gmrtd TestDoPace_CAM_ECDH_DE)
+    // -------------------------------------------------------------------
+
+    test('BrainpoolP256r1 coordLen formula: (256 + 7) ~/ 8 == 32', () {
+      // This is the formula used in ecdh_pace.dart to compute coordLen
+      // from the domain-parameter bit size.
+      const bitSize = 256;
+      expect((bitSize + 7) ~/ 8, 32);
+    });
+
+    test('gmrtd DE PACE-CAM terminal key-pair 1 coordinates are full 32 bytes', () {
+      // From gmrtd TestDoPace_CAM_ECDH_DE, terminal private key index 0:
+      //   privKey  = 01fd26013f5bc41fad8bb09811e435f16fbe2eb3c2e1d999b0f63da8c3d58bb5
+      //   pubKey X = 303f340815eea501772393e299a4a6f6694600189c249c63a8513ff3fefa66e3
+      //   pubKey Y = 46d11970b5f76fb564c3b0e54b215528f647ec5a9ab209cdbe262e763d6119a1
+      // Both coordinates are exactly 32 bytes — no padding is needed here, but
+      // the coordLen path must still produce exactly 32 bytes.
+      final xBigInt = BigInt.parse('303f340815eea501772393e299a4a6f6694600189c249c63a8513ff3fefa66e3', radix: 16);
+      final yBigInt = BigInt.parse('46d11970b5f76fb564c3b0e54b215528f647ec5a9ab209cdbe262e763d6119a1', radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
+
+      expect(pubKey.xBytes.length, 32);
+      expect(pubKey.yBytes.length, 32);
+    });
+
+    test('padding produces correct uncompressed-point byte sequence', () {
+      // Uncompressed EC point encoding: 04 || X (coordLen bytes) || Y (coordLen bytes)
+      // If X has a leading-zero byte that BigInt drops, the encoded point must still
+      // start with 04 and have exactly 1 + 2*coordLen bytes total.
+      final xBigInt = BigInt.parse('00' + 'AB' * 31, radix: 16);
+      final yBigInt = BigInt.parse('CD' * 32, radix: 16);
+
+      final pubKey = PublicKeyPACEeCDH(x: xBigInt, y: yBigInt, coordLen: 32);
+      final encoded = Uint8List.fromList([0x04, ...pubKey.xBytes, ...pubKey.yBytes]);
+
+      expect(encoded.length, 65); // 1 + 32 + 32
+      expect(encoded[0], 0x04);
+      expect(encoded[1], 0x00); // leading-zero byte preserved in X
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Reading German passports failed due to three distinct issues:

**1. PACE-CAM: wrong ChipAuthentication public key selected**

German passports expose two `ChipAuthenticationPublicKeyInfo` entries in EF.CardSecurity — one for Generic Mapping (GM, keyId=72) and one for Chip Authentication Mapping (CAM, keyId=13, matching the PACE domain parameter ID). The previous code blindly returned the first matching entry (GM key), causing the scalar multiplication in CAM verification to produce the wrong result (`[CA_IC] × PK_IC_gm ≠ PKMap_IC`).

Fix: `_extractPkIcForCAM` now prefers the entry whose `keyId == domainParameterId`, falling back to the first match.

**2. EF.CardSecurity unreadable over Secure Messaging**

German passports return `sw=6A80` when `SELECT FILE` is issued for EF.CardSecurity over SM. The file must be read using SFI-based `READ BINARY` (`P1 = 0x80 | SFI`).

Fix: `_readCardSecurity` now uses `readBinaryBySFI(sfi: 0x9D)` instead of `selectEF` + `readBinary`.

**3. Terminal ECDH coordinates not padded to field size**

For BrainpoolP256r1 (32-byte field), EC coordinates generated by the terminal were not zero-padded when the leading byte was zero, producing short byte arrays. This caused malformed public key encoding sent to the chip.

Fix: `PublicKeyPACEeCDH` now accepts a `coordLen` parameter and pads coordinates to the full field size.

**4. Active Authentication not supported gracefully**

After a successful PACE-CAM session, the reader sent an `INTERNAL AUTHENTICATE` command (INS=0x88) for Active Authentication. German passports that don't support AA return `sw=6D00` ("Instruction code not supported"), which was triggering a full session retry loop (5 attempts) before ultimately failing.

Fix: `sw=6D00` from the AA command is now caught inside the reconnection callback and treated as "AA not supported — skip", allowing the read to complete successfully.

**5. Android NFC reconnect after TagLostException**

On Android, an `IOException` could occur when re-polling after a `TagLostException` because the previous tag was not cleaned up.

Fix: `forceCleanup()` is called before reconnect on Android to ensure the NFC stack is in a clean state.