### PR TITLE
fix(aa): skip Active Authentication when chip has no DG15 (UK passports)

### DIFF
--- a/vcmrtd/lib/src/document_reader.dart
+++ b/vcmrtd/lib/src/document_reader.dart
@@ -221,7 +221,19 @@ class DocumentReader<DocType extends DocumentData> extends Notifier<DocumentRead
     }
 
     Uint8List? aaSig;
-    if (activeAuthenticationParams != null) {
+    // Active Authentication proves the chip holds the private key matching the
+    // AA public key stored in DG15. If the chip carries no DG15 there is no AA
+    // key to challenge, so attempting it makes the chip reply 6A88 "referenced
+    // data not found" (or 6D00/6A81). This is common for documents that rely on
+    // Chip Authentication (EAC) instead of AA, e.g. many UK passports. Only
+    // attempt AA when DG15 is actually present; the passport issuer accepts a
+    // missing AA signature for such documents (passive authentication of the
+    // SOD still applies).
+    final chipSupportsAA = documentParser.documentContainsDataGroup(DataGroups.dg15);
+    if (activeAuthenticationParams != null && !chipSupportsAA) {
+      _addLog("Skipping Active Authentication: DG15 (AA public key) not present on chip");
+    }
+    if (activeAuthenticationParams != null && chipSupportsAA) {
       _setState(DocumentReaderActiveAuthentication());
       try {
         await _reconnectionLoop(
@@ -230,8 +242,14 @@ class DocumentReader<DocType extends DocumentData> extends Notifier<DocumentRead
             try {
               aaSig = await dataGroupReader.activeAuthenticate(stringToUint8List(activeAuthenticationParams.nonce));
             } on DocumentError catch (e) {
-              if (e.code == StatusWord.invalidInstructionCode) {
-                _addLog("Active Authentication not supported by chip (sw=6D00), skipping");
+              // Some chips advertise no usable AA key and reject the command
+              // outright. Treat these "not supported" status words as AA being
+              // unavailable and skip, rather than failing the whole read.
+              if (e.code == StatusWord.invalidInstructionCode || // 6D00
+                  e.code == StatusWord.referencedDataNotFound || // 6A88
+                  e.code == StatusWord.notSupported) {
+                // 6A81
+                _addLog("Active Authentication not supported by chip (${e.code}), skipping");
                 return;
               }
               rethrow;

--- a/vcmrtd/test/document_reader_test.dart
+++ b/vcmrtd/test/document_reader_test.dart
@@ -406,8 +406,8 @@ void main() {
       expect(h.nfc.disconnectCount, greaterThanOrEqualTo(1));
     });
 
-    test('with activeAuthenticationParams produces an AA signature', () async {
-      final h = makeHarness(present: {DataGroups.dg1, DataGroups.dg2});
+    test('with activeAuthenticationParams produces an AA signature (DG15 present)', () async {
+      final h = makeHarness(present: {DataGroups.dg1, DataGroups.dg2, DataGroups.dg15});
       final params = NonceAndSessionId(nonce: '0102030405060708', sessionId: 'sess-1');
       final result = await h.reader.readDocument(iosNfcMessages: _msg, activeAuthenticationParams: params);
 
@@ -419,9 +419,24 @@ void main() {
       expect(h.dgr.calls.contains('AA'), true);
     });
 
+    test('AA skipped entirely when DG15 absent (no AA command sent), read succeeds', () async {
+      // A UK passport that relies on Chip Authentication carries no DG15; AA must
+      // not be attempted at all, so the chip is never sent an INTERNAL AUTHENTICATE
+      // (which would answer 6A88 and abort the read).
+      final h = makeHarness(present: {DataGroups.dg1, DataGroups.dg2});
+      final params = NonceAndSessionId(nonce: '0102030405060708', sessionId: 'sess-no-dg15');
+      final result = await h.reader.readDocument(iosNfcMessages: _msg, activeAuthenticationParams: params);
+
+      expect(result, isNotNull);
+      expect(h.state, isA<DocumentReaderSuccess>());
+      expect(h.dgr.calls.contains('AA'), false);
+      expect(result!.$2.aaSignature, isNull);
+      expect(h.reader.getLogs(), contains('Skipping Active Authentication'));
+    });
+
     test('AA invalidInstructionCode (6D00) is skipped, read still succeeds', () async {
       final h = makeHarness(
-        present: {DataGroups.dg1, DataGroups.dg2},
+        present: {DataGroups.dg1, DataGroups.dg2, DataGroups.dg15},
         steps: {
           'AA': [_Step.fail(DocumentError('unsupported', code: StatusWord.invalidInstructionCode))],
         },
@@ -432,6 +447,23 @@ void main() {
       expect(result, isNotNull);
       expect(h.state, isA<DocumentReaderSuccess>());
       // signature stays null because AA was skipped
+      expect(result!.$2.aaSignature, isNull);
+    });
+
+    test('AA referencedDataNotFound (6A88) is skipped, read still succeeds', () async {
+      // The chip reports DG15 but rejects INTERNAL AUTHENTICATE with 6A88; treat
+      // it as "AA unavailable" and skip rather than aborting the whole read.
+      final h = makeHarness(
+        present: {DataGroups.dg1, DataGroups.dg2, DataGroups.dg15},
+        steps: {
+          'AA': [_Step.fail(DocumentError('Referenced data not found', code: StatusWord.referencedDataNotFound))],
+        },
+      );
+      final params = NonceAndSessionId(nonce: '0102030405060708', sessionId: 'sess-6a88');
+      final result = await h.reader.readDocument(iosNfcMessages: _msg, activeAuthenticationParams: params);
+
+      expect(result, isNotNull);
+      expect(h.state, isA<DocumentReaderSuccess>());
       expect(result!.$2.aaSignature, isNull);
     });
   });
@@ -500,9 +532,9 @@ void main() {
       expect(h.state, isA<DocumentReaderFailed>());
     });
 
-    test('AA failure (non-6D00) -> Failed', () async {
+    test('AA hard failure with DG15 present (non-"unsupported" status) -> Failed', () async {
       final h = makeHarness(
-        present: {DataGroups.dg1, DataGroups.dg2},
+        present: {DataGroups.dg1, DataGroups.dg2, DataGroups.dg15},
         steps: {'AA': List.generate(5, (_) => _Step.fail(DocumentError('aa hard fail')))},
       );
       final params = NonceAndSessionId(nonce: '0102030405060708', sessionId: 's');


### PR DESCRIPTION
Fixes #171.

## Problem

Active Authentication was attempted whenever `activeAuthenticationParams` were supplied, without checking whether the chip actually carries an AA public key (DG15). Chips without DG15 — common for documents that use Chip Authentication (EAC) instead of AA, e.g. many UK passports — answer `INTERNAL AUTHENTICATE` with SW `6A88` ("referenced data not found"). Only `6D00` was tolerated, so `6A88` was retried 5× and then aborted the **entire** read, even though all mandatory data had already been read successfully.

Reported by a UK prospect scanning a UK passport on Android (log in #171).

## Fix

- **Gate AA on DG15 presence** (`documentContainsDataGroup(DataGroups.dg15)`). When absent, AA is skipped cleanly and logged — no `INTERNAL AUTHENTICATE` is sent, so the 6A88 + 5×-retry path is avoided entirely. This mirrors the `gmrtd` reference implementation, which skips AA when `Dg15 == nil`.
- **Extend the graceful "AA unsupported" skip** to also cover `6A88` (`referencedDataNotFound`) and `6A81` (`notSupported`) alongside the existing `6D00`, for chips that report DG15 but still reject the command.

Genuine AA failures when DG15 *is* present remain fatal (the retry loop already absorbs transient errors).

## Backend

Confirmed against `go-passport-issuer`: its `ActiveAuthentication` returns `(false, nil)` when the document has no DG15 (issues without AA; passive authentication of the SOD stays mandatory), and only requires a nonce+signature when DG15 is present. So a readout with `aa_signature: null` for these documents is accepted — no backend change needed. Full cross-reference (gmrtd + irmamobile + go-passport-issuer) is in #171.

## Tests

- AA skipped entirely when DG15 absent (asserts no AA command sent, read succeeds, null signature).
- AA `6A88` skipped, read still succeeds (DG15 present).
- Updated existing AA tests to include DG15 so they exercise the intended paths; genuine AA hard-failure with DG15 present still fails.
