### PR TITLE
fix: perform Active Authentication for driving licences (DG13)

### DIFF
--- a/vcmrtd/lib/src/document_reader.dart
+++ b/vcmrtd/lib/src/document_reader.dart
@@ -222,16 +222,17 @@ class DocumentReader<DocType extends DocumentData> extends Notifier<DocumentRead
 
     Uint8List? aaSig;
     // Active Authentication proves the chip holds the private key matching the
-    // AA public key stored in DG15. If the chip carries no DG15 there is no AA
-    // key to challenge, so attempting it makes the chip reply 6A88 "referenced
-    // data not found" (or 6D00/6A81). This is common for documents that rely on
+    // AA public key stored on the chip (DG15 for passports/ID cards, DG13 for
+    // driving licences). If the chip carries no such key there is nothing to
+    // challenge, so attempting it makes the chip reply 6A88 "referenced data
+    // not found" (or 6D00/6A81). This is common for documents that rely on
     // Chip Authentication (EAC) instead of AA, e.g. many UK passports. Only
-    // attempt AA when DG15 is actually present; the passport issuer accepts a
+    // attempt AA when the AA key is actually present; the issuer accepts a
     // missing AA signature for such documents (passive authentication of the
     // SOD still applies).
-    final chipSupportsAA = documentParser.documentContainsDataGroup(DataGroups.dg15);
+    final chipSupportsAA = documentParser.documentSupportsActiveAuthentication();
     if (activeAuthenticationParams != null && !chipSupportsAA) {
-      _addLog("Skipping Active Authentication: DG15 (AA public key) not present on chip");
+      _addLog("Skipping Active Authentication: AA public key not present on chip");
     }
     if (activeAuthenticationParams != null && chipSupportsAA) {
       _setState(DocumentReaderActiveAuthentication());

--- a/vcmrtd/lib/src/parsers/document_parser.dart
+++ b/vcmrtd/lib/src/parsers/document_parser.dart
@@ -24,6 +24,14 @@ abstract class DocumentParser<DocType extends DocumentData> {
 
   bool documentContainsDataGroup(DataGroups dg);
 
+  /// Whether the chip carries Active Authentication key material and therefore
+  /// supports the AA challenge-response.
+  ///
+  /// Defaults to DG15, where passports and ID cards store the AA public key.
+  /// Documents that keep the AA public key in a different data group (e.g.
+  /// driving licences use DG13) override this.
+  bool documentSupportsActiveAuthentication() => documentContainsDataGroup(DataGroups.dg15);
+
   void parseDG1(Uint8List bytes);
   void parseDG2(Uint8List bytes);
   void parseDG3(Uint8List bytes);

--- a/vcmrtd/lib/src/parsers/driving_licence_parser.dart
+++ b/vcmrtd/lib/src/parsers/driving_licence_parser.dart
@@ -60,6 +60,11 @@ class DrivingLicenceParser extends DocumentParser<DrivingLicenceData> {
     return com.dgTags.contains(_tagForDataGroup(dg));
   }
 
+  /// Driving licences carry the Active Authentication public key in DG13
+  /// (there is no DG15), so AA is supported whenever DG13 is present.
+  @override
+  bool documentSupportsActiveAuthentication() => documentContainsDataGroup(DataGroups.dg13);
+
   DgTag? _tagForDataGroup(DataGroups dg) {
     return switch (dg) {
       DataGroups.dg1 => DrivingLicenceEfDG1.TAG,

--- a/vcmrtd/test/document_reader_test.dart
+++ b/vcmrtd/test/document_reader_test.dart
@@ -177,6 +177,15 @@ class FakeDocumentParser extends DocumentParser<DocumentData> {
   final List<String> parsed = [];
   bool throwOnEfCom = false;
 
+  /// When true, advertises Active Authentication via DG13 (as driving licences
+  /// do) instead of the DG15 default, exercising the
+  /// documentSupportsActiveAuthentication override path.
+  bool aaViaDg13 = false;
+
+  @override
+  bool documentSupportsActiveAuthentication() =>
+      aaViaDg13 ? present.contains(DataGroups.dg13) : super.documentSupportsActiveAuthentication();
+
   FakeDocumentParser({Set<DataGroups>? present, Set<DataGroups>? throwOnParse})
     : present = present ?? const {},
       throwOnParse = throwOnParse ?? const {};
@@ -275,6 +284,7 @@ Harness makeHarness({
   Object? startSessionPaceError,
   bool throwOnEfCom = false,
   bool nfcConnected = false,
+  bool aaViaDg13 = false,
   DocumentReaderConfig? config,
 }) {
   final nfc = FakeNfcProvider(connected: nfcConnected);
@@ -283,6 +293,7 @@ Harness makeHarness({
   dgr.startSessionPaceError = startSessionPaceError;
   final parser = FakeDocumentParser(present: present, throwOnParse: throwOnParse);
   parser.throwOnEfCom = throwOnEfCom;
+  parser.aaViaDg13 = aaViaDg13;
 
   final cfg = config ?? DocumentReaderConfig(readIfAvailable: DataGroups.values.toSet());
 
@@ -415,6 +426,20 @@ void main() {
       final raw = result!.$2;
       expect(raw.sessionId, 'sess-1');
       expect(raw.nonce, isNotNull);
+      expect(raw.aaSignature, isNotNull);
+      expect(h.dgr.calls.contains('AA'), true);
+    });
+
+    test('with activeAuthenticationParams produces an AA signature for an eDL (DG13, no DG15)', () async {
+      // Driving licences carry the AA public key in DG13 and have no DG15;
+      // the reader must still perform AA via documentSupportsActiveAuthentication.
+      final h = makeHarness(present: {DataGroups.dg1, DataGroups.dg2, DataGroups.dg13}, aaViaDg13: true);
+      final params = NonceAndSessionId(nonce: '0102030405060708', sessionId: 'sess-edl');
+      final result = await h.reader.readDocument(iosNfcMessages: _msg, activeAuthenticationParams: params);
+
+      expect(result, isNotNull);
+      final raw = result!.$2;
+      expect(raw.sessionId, 'sess-edl');
       expect(raw.aaSignature, isNotNull);
       expect(h.dgr.calls.contains('AA'), true);
     });

--- a/vcmrtd/test/driving_licence_parser_extra_test.dart
+++ b/vcmrtd/test/driving_licence_parser_extra_test.dart
@@ -148,6 +148,22 @@ void main() {
     });
   });
 
+  group('documentSupportsActiveAuthentication', () {
+    test('true when EF.COM lists DG13 (0x6f) — the eDL AA public key', () {
+      final parser = DrivingLicenceParser(failDg1CategoriesGracefully: false);
+      // EF.COM tag list (5C) includes 0x6f (DG13) alongside DG1/DG5/DG11.
+      parser.parseEfCOM(hexb("60165F0104303130375F36063034303030305C0461676d6f"));
+      expect(parser.documentSupportsActiveAuthentication(), true);
+    });
+
+    test('false when EF.COM does not list DG13', () {
+      final parser = DrivingLicenceParser(failDg1CategoriesGracefully: false);
+      // Same EF.COM without 0x6f (DG13) in the tag list.
+      parser.parseEfCOM(hexb("60155F0104303130375F36063034303030305C0361676d"));
+      expect(parser.documentSupportsActiveAuthentication(), false);
+    });
+  });
+
   group('valid DG1 categories parse', () {
     test('ascii DG1 produces categories', () {
       final parser = DrivingLicenceParser(failDg1CategoriesGracefully: false);


### PR DESCRIPTION
## Problem

Every eDL issuance broke after the passport-issuer backend hardened its Active Authentication (AA) policy to require AA whenever the chip advertises AA key material. The backend was correct; the app never satisfied it.

The document reader gated AA solely on **DG15** presence — where passports and ID cards store the AA public key. **Driving licences have no DG15**; they carry the AA public key in **DG13**. So `chipSupportsAA` was always `false` for eDLs: the INTERNAL AUTHENTICATE challenge was never sent, and the read produced `aa_signature: null`. The backend then rejected every eDL with `ErrActiveAuthRequired` (HTTP 400).

## Fix

- Add `DocumentParser.documentSupportsActiveAuthentication()`, defaulting to DG15 (behavior unchanged for passports/ID cards).
- Override it in `DrivingLicenceParser` to check **DG13**.
- The document reader now gates AA on this method instead of hardcoding DG15.

The chip-side challenge (`activeAuthenticate` / INTERNAL AUTHENTICATE) is data-group agnostic, so an eDL chip carrying DG13 is now challenged and produces a real `aa_signature`. This restores eDL issuance without weakening the backend's AA enforcement.

## Tests

- `documentSupportsActiveAuthentication` unit cases for the eDL parser (DG13 present → true, absent → false).
- Reader-level test asserting AA fires and a signature is produced for an eDL-style document (DG13, no DG15).

## Downstream

Requires a new vcmrtd release/tag and a dependency bump in irmamobile to reach the app.